### PR TITLE
refactor(ui): extract ProcessCard and simplify list

### DIFF
--- a/frontend/src/components/conversation/ConversationList.tsx
+++ b/frontend/src/components/conversation/ConversationList.tsx
@@ -1,16 +1,7 @@
 import { useTranslation } from "react-i18next";
-import { Badge } from "../ui/badge";
+
 import { Button } from "../ui/button";
-import { Card, CardHeader, CardContent } from "../ui/card";
-import {
-  Dialog,
-  DialogContent,
-  DialogHeader,
-  DialogTitle,
-  DialogDescription,
-  DialogFooter,
-  DialogTrigger,
-} from "../ui/dialog";
+
 import {
   Select,
   SelectContent,
@@ -21,7 +12,7 @@ import {
 import { Tooltip, TooltipContent, TooltipTrigger } from "../ui/tooltip";
 import { Input } from "../ui/input";
 import { Checkbox } from "../ui/checkbox";
-import { X, MessageCircle, Clock, AlertTriangle } from "lucide-react";
+import { X, MessageCircle, AlertTriangle } from "lucide-react";
 import { useState, useCallback } from "react";
 import { webApi, SearchResult, SearchFilters } from "../../lib/webApi";
 import { SearchInput } from "../common/SearchInput";
@@ -31,6 +22,7 @@ import { GeminiAuthMethod } from "../../types/backend";
 import { useBackend, useBackendConfig } from "../../contexts/BackendContext";
 import { getBackendText } from "../../utils/backendText";
 import type { Conversation, ProcessStatus } from "../../types";
+import { ProcessCard } from "./ProcessCard";
 
 interface ConversationListProps {
   conversations: Conversation[];
@@ -504,135 +496,18 @@ export function ConversationList({
               const isSelected = activeConversation === conversation.id;
 
               return (
-                <Card
+                <ProcessCard
                   key={conversation.id}
-                  className={`cursor-pointer transition-all hover:shadow-md ${
-                    isSelected
-                      ? "ring-2 ring-blue-500 bg-blue-50 dark:bg-blue-900/20"
-                      : "hover:bg-gray-100 dark:hover:bg-gray-700"
-                  }`}
-                  onClick={async () =>
-                    await onConversationSelect(conversation.id)
-                  }
-                >
-                  <CardHeader className="p-3 pb-2 py-0">
-                    <div className="flex items-start justify-between gap-2">
-                      <div className="flex-1 min-w-0">
-                        <h3 className="font-medium text-sm text-gray-900 dark:text-gray-100 truncate wrap-normal">
-                          {conversation.title.length > 20
-                            ? conversation.title.slice(0, 35) + "..."
-                            : conversation.title}
-                        </h3>
-                        <div className="flex items-center gap-2 mt-1 justify-between">
-                          {/* Process Status Badge */}
-                          <div className="flex items-center gap-1">
-                            {isActive ? (
-                              <Badge
-                                variant="secondary"
-                                className="bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-200 text-xs px-2 py-0.5"
-                              >
-                                <div className="w-2 h-2 bg-green-500 rounded-full mr-1" />
-                                {processStatus?.pid
-                                  ? t("conversations.pidLabel", {
-                                      pid: processStatus.pid,
-                                    })
-                                  : t("conversations.active")}
-                                {/* End Chat Button */}
-                                {isActive && (
-                                  <Dialog
-                                    open={
-                                      selectedConversationForEnd?.id ===
-                                      conversation.id
-                                    }
-                                    onOpenChange={(open) => {
-                                      if (!open)
-                                        setSelectedConversationForEnd(null);
-                                    }}
-                                  >
-                                    <DialogTrigger asChild>
-                                      <Button
-                                        variant="ghost"
-                                        size="sm"
-                                        className="h-4 w-4 p-0 ml-2 text-red-500 hover:text-red-700 hover:bg-red-100 dark:hover:bg-red-950/70"
-                                        onClick={(e) => {
-                                          e.stopPropagation(); // Prevent conversation selection
-                                          setSelectedConversationForEnd({
-                                            id: conversation.id,
-                                            title: conversation.title,
-                                          });
-                                        }}
-                                        title={t("conversations.endChat")}
-                                      >
-                                        <X className="h-4 w-4" />
-                                      </Button>
-                                    </DialogTrigger>
-                                    <DialogContent>
-                                      <DialogHeader>
-                                        <DialogTitle>
-                                          {t("conversations.endChat")}
-                                        </DialogTitle>
-                                        <DialogDescription>
-                                          {t("conversations.endChatConfirm", {
-                                            title: conversation.title,
-                                          })}
-                                        </DialogDescription>
-                                      </DialogHeader>
-                                      <DialogFooter>
-                                        <Button
-                                          variant="outline"
-                                          onClick={() =>
-                                            setSelectedConversationForEnd(null)
-                                          }
-                                        >
-                                          {t("common.cancel")}
-                                        </Button>
-                                        <Button
-                                          variant="destructive"
-                                          onClick={() => {
-                                            onKillProcess(conversation.id);
-                                            setSelectedConversationForEnd(null);
-                                          }}
-                                        >
-                                          {t("conversations.endChat")}
-                                        </Button>
-                                      </DialogFooter>
-                                    </DialogContent>
-                                  </Dialog>
-                                )}
-                              </Badge>
-                            ) : (
-                              <Badge
-                                variant="secondary"
-                                className="bg-gray-100 text-gray-600 dark:bg-gray-700 dark:text-gray-400 text-xs px-2 py-0.5"
-                              >
-                                <div className="w-2 h-2 bg-gray-400 rounded-full mr-1" />
-                                {t("conversations.inactive")}
-                              </Badge>
-                            )}
-                          </div>
-                          <div className="flex items-center gap-2 mt-1">
-                            <Clock className="h-3 w-3 text-gray-400" />
-                            <span className="text-xs text-gray-500 dark:text-gray-400">
-                              {formatLastUpdated(conversation.lastUpdated)}
-                            </span>
-                          </div>
-                        </div>
-                      </div>
-                    </div>
-                  </CardHeader>
-
-                  <CardContent className="p-3 pb-0">
-                    <div className="flex items-center justify-between">
-                      <div className="flex-1">
-                        <p className="text-xs text-gray-500 dark:text-gray-400">
-                          {t("conversations.messageCount", {
-                            count: conversation.messages.length,
-                          })}
-                        </p>
-                      </div>
-                    </div>
-                  </CardContent>
-                </Card>
+                  conversation={conversation}
+                  processStatus={processStatus}
+                  isActive={isActive}
+                  isSelected={isSelected}
+                  onConversationSelect={(id) => void onConversationSelect(id)}
+                  onKillProcess={onKillProcess}
+                  selectedConversationForEnd={selectedConversationForEnd}
+                  setSelectedConversationForEnd={setSelectedConversationForEnd}
+                  formatLastUpdated={formatLastUpdated}
+                />
               );
             })
         )}

--- a/frontend/src/components/conversation/ProcessCard.tsx
+++ b/frontend/src/components/conversation/ProcessCard.tsx
@@ -1,0 +1,287 @@
+import { Button } from "../ui/button";
+import {
+  Dialog,
+  DialogTrigger,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+  DialogFooter,
+} from "../ui/dialog";
+import { X } from "lucide-react";
+import { useTranslation } from "react-i18next";
+import type { Conversation, ProcessStatus } from "../../types";
+
+interface ProcessCardProps {
+  conversation: Conversation;
+  processStatus: ProcessStatus | undefined;
+  isActive: boolean;
+  isSelected: boolean;
+  onConversationSelect: (id: string) => void;
+  onKillProcess: (id: string) => void;
+  selectedConversationForEnd: { id: string; title: string } | null;
+  setSelectedConversationForEnd: (
+    value: { id: string; title: string } | null
+  ) => void;
+  formatLastUpdated: (date: Date) => string;
+}
+
+export function ProcessCard({
+  conversation,
+  processStatus,
+  isActive,
+  isSelected,
+  onConversationSelect,
+  onKillProcess,
+  selectedConversationForEnd,
+  setSelectedConversationForEnd,
+  formatLastUpdated,
+}: ProcessCardProps) {
+  const { t } = useTranslation();
+
+  // Hidden developer feature flag - change to true to enable new Panel design with gradients
+  const ENABLE_NEW_PANEL_DESIGN = false;
+
+  // Generate deterministic colors based on session ID (for new panel design)
+  const generateSessionColors = (sessionId: string) => {
+    // Simple hash function for consistent color generation
+    let hash1 = 0;
+    let hash2 = 0;
+    for (let i = 0; i < sessionId.length; i++) {
+      hash1 = ((hash1 << 5) - hash1 + sessionId.charCodeAt(i)) & 0xffffffff;
+      hash2 = ((hash2 << 3) + hash2 + sessionId.charCodeAt(i) * 7) & 0xffffffff;
+    }
+
+    // Generate HSL colors for better visual consistency
+    const hue1 = Math.abs(hash1) % 360;
+    const hue2 = Math.abs(hash2) % 360;
+    const saturation = 45 + (Math.abs(hash1 >> 8) % 30); // 45-75%
+    const lightness = 40 + (Math.abs(hash1 >> 16) % 25); // 40-65%
+
+    return {
+      from: `hsl(${hue1}, ${saturation}%, ${lightness}%)`,
+      to: `hsl(${hue2}, ${saturation}%, ${lightness}%)`,
+    };
+  };
+
+  const sessionColors = generateSessionColors(conversation.id);
+
+  const renderKillButton = () => (
+    <Dialog
+      open={selectedConversationForEnd?.id === conversation.id}
+      onOpenChange={(open) => {
+        if (!open) setSelectedConversationForEnd(null);
+      }}
+    >
+      <DialogTrigger asChild>
+        <Button
+          variant="ghost"
+          size="sm"
+          className="h-4 w-4 p-0 text-white/80 hover:bg-white/20"
+          onClick={(e) => {
+            e.stopPropagation();
+            setSelectedConversationForEnd({
+              id: conversation.id,
+              title: conversation.title,
+            });
+          }}
+          title={t("conversations.endChat")}
+        >
+          <X className="h-3 w-3" />
+        </Button>
+      </DialogTrigger>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>{t("conversations.endChat")}</DialogTitle>
+          <DialogDescription>
+            {t("conversations.endChatConfirm", { title: conversation.title })}
+          </DialogDescription>
+        </DialogHeader>
+        <DialogFooter>
+          <Button
+            variant="outline"
+            onClick={() => setSelectedConversationForEnd(null)}
+          >
+            {t("common.cancel")}
+          </Button>
+          <Button
+            variant="destructive"
+            onClick={() => {
+              onKillProcess(conversation.id);
+              setSelectedConversationForEnd(null);
+            }}
+          >
+            {t("conversations.endChat")}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+
+  if (ENABLE_NEW_PANEL_DESIGN) {
+    // New Panel Design with gradients
+    return (
+      <div
+        className={`border rounded-md cursor-pointer transition-all mb-2 overflow-hidden ${
+          isSelected
+            ? "shadow-md"
+            : "hover:border-gray-300 dark:hover:border-gray-600"
+        }`}
+        style={{
+          borderColor: isActive ? sessionColors.from : undefined,
+        }}
+        onClick={() => onConversationSelect(conversation.id)}
+      >
+        <div
+          className={`px-3 py-2 text-xs font-medium ${
+            isActive
+              ? "text-white"
+              : "bg-gray-100 dark:bg-gray-800 text-gray-700 dark:text-gray-300"
+          }`}
+          style={{
+            background: isActive
+              ? `linear-gradient(135deg, ${sessionColors.from}, ${sessionColors.to})`
+              : undefined,
+          }}
+        >
+          <div className="flex justify-between items-center">
+            <span>Session {conversation.id.slice(-6).toUpperCase()}</span>
+            {isActive && renderKillButton()}
+          </div>
+        </div>
+        <div className="p-3">
+          <h4 className="font-medium text-sm mb-2">{conversation.title}</h4>
+          <div className="grid grid-cols-2 gap-2 text-xs text-gray-600 dark:text-gray-400">
+            <div>Messages: {conversation.messages.length}</div>
+            <div>PID: {processStatus?.pid || "None"}</div>
+            <div className="col-span-2">
+              Updated: {formatLastUpdated(conversation.lastUpdated)}
+            </div>
+          </div>
+        </div>
+        {isActive && renderKillButton()}
+      </div>
+    );
+  } else {
+    // Original old card design (before we started)
+    return (
+      <div
+        key={conversation.id}
+        className={`cursor-pointer transition-all hover:shadow-md ${
+          isSelected
+            ? "ring-2 ring-blue-500 bg-blue-50 dark:bg-blue-900/20"
+            : "hover:bg-gray-100 dark:hover:bg-gray-700"
+        }`}
+        onClick={() => onConversationSelect(conversation.id)}
+      >
+        <div className="p-3 pb-2 py-0">
+          <div className="flex items-start justify-between gap-2">
+            <div className="flex-1 min-w-0">
+              <h3 className="font-medium text-sm text-gray-900 dark:text-gray-100 truncate wrap-normal">
+                {conversation.title.length > 20
+                  ? conversation.title.slice(0, 35) + "..."
+                  : conversation.title}
+              </h3>
+              <div className="flex items-center gap-2 mt-1 justify-between">
+                <div className="flex items-center gap-1">
+                  {isActive ? (
+                    <div className="bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-200 text-xs px-2 py-0.5 rounded">
+                      <div className="w-2 h-2 bg-green-500 rounded-full mr-1 inline-block" />
+                      {processStatus?.pid
+                        ? t("conversations.pidLabel", {
+                            pid: processStatus.pid,
+                          })
+                        : t("conversations.active")}
+                      {isActive && (
+                        <Dialog
+                          open={
+                            selectedConversationForEnd?.id === conversation.id
+                          }
+                          onOpenChange={(open) => {
+                            if (!open) setSelectedConversationForEnd(null);
+                          }}
+                        >
+                          <DialogTrigger asChild>
+                            <Button
+                              variant="ghost"
+                              size="sm"
+                              className="h-4 w-4 p-0 ml-2 text-red-500 hover:text-red-700 hover:bg-red-100 dark:hover:bg-red-950/70"
+                              onClick={(e) => {
+                                e.stopPropagation();
+                                setSelectedConversationForEnd({
+                                  id: conversation.id,
+                                  title: conversation.title,
+                                });
+                              }}
+                              title={t("conversations.endChat")}
+                            >
+                              <X className="h-4 w-4" />
+                            </Button>
+                          </DialogTrigger>
+                          <DialogContent>
+                            <DialogHeader>
+                              <DialogTitle>
+                                {t("conversations.endChat")}
+                              </DialogTitle>
+                              <DialogDescription>
+                                {t("conversations.endChatConfirm", {
+                                  title: conversation.title,
+                                })}
+                              </DialogDescription>
+                            </DialogHeader>
+                            <DialogFooter>
+                              <Button
+                                variant="outline"
+                                onClick={() =>
+                                  setSelectedConversationForEnd(null)
+                                }
+                              >
+                                {t("common.cancel")}
+                              </Button>
+                              <Button
+                                variant="destructive"
+                                onClick={() => {
+                                  onKillProcess(conversation.id);
+                                  setSelectedConversationForEnd(null);
+                                }}
+                              >
+                                {t("conversations.endChat")}
+                              </Button>
+                            </DialogFooter>
+                          </DialogContent>
+                        </Dialog>
+                      )}
+                    </div>
+                  ) : (
+                    <div className="bg-gray-100 text-gray-600 dark:bg-gray-700 dark:text-gray-400 text-xs px-2 py-0.5 rounded">
+                      <div className="w-2 h-2 bg-gray-400 rounded-full mr-1 inline-block" />
+                      {t("conversations.inactive")}
+                    </div>
+                  )}
+                </div>
+                <div className="flex items-center gap-2 mt-1">
+                  <div className="h-3 w-3 text-gray-400">🕐</div>
+                  <span className="text-xs text-gray-500 dark:text-gray-400">
+                    {formatLastUpdated(conversation.lastUpdated)}
+                  </span>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <div className="p-3 pb-0">
+          <div className="flex items-center justify-between">
+            <div className="flex-1">
+              <p className="text-xs text-gray-500 dark:text-gray-400">
+                {t("conversations.messageCount", {
+                  count: conversation.messages.length,
+                })}
+              </p>
+            </div>
+          </div>
+        </div>
+      </div>
+    );
+  }
+}


### PR DESCRIPTION
- Move card UI logic from `ConversationList` into a new `ProcessCard` component

- Remove unused imports and streamline the component hierarchy

- Update `ConversationList` to render `ProcessCard` with appropriate props

- Add optional new panel design flag (disabled by default) for future UI experiments