### PR TITLE
feat(yolo): add YOLO mode support across backend, server, and UI

### DIFF
--- a/crates/backend/src/session/mod.rs
+++ b/crates/backend/src/session/mod.rs
@@ -1,10 +1,13 @@
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
+use std::io;
 use std::process::Stdio;
 use std::sync::{Arc, Mutex};
 use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader as AsyncBufReader};
 use tokio::process::{Child, ChildStdin, ChildStdout, Command};
+use tokio::select;
 use tokio::sync::mpsc;
+use tokio::time::{Duration, sleep};
 
 #[cfg(windows)]
 const CREATE_NO_WINDOW: u32 = 0x08000000;
@@ -22,6 +25,7 @@ pub struct GeminiAuthConfig {
     pub api_key: Option<String>,
     pub vertex_project: Option<String>,
     pub vertex_location: Option<String>,
+    pub yolo: Option<bool>,
 }
 
 use crate::acp::{
@@ -206,7 +210,7 @@ async fn send_jsonrpc_request<E: EventEmitter>(
     session_id: &str,
     emitter: &E,
     rpc_logger: &Arc<dyn RpcLogger>,
-) -> BackendResult<JsonRpcResponse> {
+) -> BackendResult<Option<JsonRpcResponse>> {
     let request_json = serde_json::to_string(request).map_err(|e| {
         BackendError::SessionInitFailed(format!("Failed to serialize request: {e}"))
     })?;
@@ -240,12 +244,19 @@ async fn send_jsonrpc_request<E: EventEmitter>(
     let mut line = String::new();
     let trimmed_line = loop {
         line.clear();
-        reader.read_line(&mut line).await.map_err(|e| {
-            BackendError::SessionInitFailed(format!("Failed to read response: {e}"))
-        })?;
+        select! {
+            result = reader.read_line(&mut line) => {
+                if let Err(e) = result {
+                    return Err(BackendError::SessionInitFailed(e.to_string()));
+                }
+            }
+            _ = sleep(Duration::from_secs(5)) => {
+                return Ok(None);
+            }
+        }
 
         let trimmed = line.trim();
-        println!("🔍 RAW OUTPUT FROM GEMINI CLI: {trimmed}");
+        print!("🔍 RAW OUTPUT FROM GEMINI CLI: [[ {trimmed}");
 
         let _ = rpc_logger.log_rpc(trimmed);
 
@@ -259,18 +270,20 @@ async fn send_jsonrpc_request<E: EventEmitter>(
 
         // Skip non-JSON lines like "Data collection is disabled."
         if trimmed.is_empty() || (!trimmed.starts_with('{') && !trimmed.starts_with('[')) {
-            println!("🔍 Skipping non-JSON line: {trimmed}");
+            println!(" ]] not JSON, skipping");
             continue;
         }
 
         // Try to parse as JSON - if it fails, continue reading
         if serde_json::from_str::<serde_json::Value>(trimmed).is_ok() {
+            println!(" ]] valid JSON");
             break trimmed.to_string();
         } else {
-            println!("🔍 Line is not valid JSON, continuing: {trimmed}");
+            println!(" ]] not JSON");
             continue;
         }
     };
+    println!("Out of loop");
 
     let response = serde_json::from_str::<JsonRpcResponse>(&trimmed_line)
         .map_err(|e| BackendError::SessionInitFailed(format!("Failed to parse response: {e}")))?;
@@ -281,7 +294,7 @@ async fn send_jsonrpc_request<E: EventEmitter>(
         )));
     }
 
-    Ok(response)
+    Ok(Some(response))
 }
 
 pub async fn initialize_session<E: EventEmitter + 'static>(
@@ -403,21 +416,47 @@ pub async fn initialize_session<E: EventEmitter + 'static>(
 
             #[cfg(windows)]
             {
-                println!(
-                    "🔧 [HANDSHAKE] Creating Windows Gemini command: cmd.exe /C gemini --model {model} --experimental-acp"
-                );
+                let yolo_flag = gemini_auth.as_ref().and_then(|a| a.yolo).unwrap_or(false);
+                // Use the working gemini executable path instead of just "gemini"
+                let gemini_path = r"gemini";
+                let mut args = vec!["/C", gemini_path, "--model", &model];
+                if yolo_flag {
+                    args.push("--yolo");
+                }
+                args.push("--experimental-acp");
+
+                let command_display = if yolo_flag {
+                    format!(
+                        "cmd.exe /C {} --model {model} --yolo --experimental-acp",
+                        gemini_path
+                    )
+                } else {
+                    format!(
+                        "cmd.exe /C {} --model {model} --experimental-acp",
+                        gemini_path
+                    )
+                };
+                println!("🔧 [HANDSHAKE] Creating Windows Gemini command: {command_display}");
+                println!("🚀 YOLO-DEBUG: Full args array: {:?}", args);
+
                 let mut c = Command::new("cmd.exe");
-                c.args(["/C", "gemini", "--model", &model, "--experimental-acp"]);
+                c.args(args);
                 c.creation_flags(CREATE_NO_WINDOW);
                 c
             }
             #[cfg(not(windows))]
             {
-                let gemini_command = format!("gemini --model {model} --experimental-acp");
+                let yolo_flag = gemini_auth.as_ref().and_then(|a| a.yolo).unwrap_or(false);
+                let gemini_command = if yolo_flag {
+                    format!("gemini --model {model} --yolo --experimental-acp")
+                } else {
+                    format!("gemini --model {model} --experimental-acp")
+                };
                 println!(
                     "🔧 [HANDSHAKE] Creating Unix Gemini command: sh -lc '{}'",
                     gemini_command
                 );
+                println!("🚀 YOLO-DEBUG: Full command string: {}", gemini_command);
                 let mut c = Command::new("sh");
                 c.args(["-lc", &gemini_command]);
                 c
@@ -435,6 +474,104 @@ pub async fn initialize_session<E: EventEmitter + 'static>(
     }
 
     println!("🔄 [HANDSHAKE] Spawning CLI process...");
+    println!("🚀 YOLO-DEBUG: About to spawn command: {:?}", cmd);
+
+    println!("🚀 YOLO-DEBUG: Testing CLI version before spawn...");
+    let version_output = {
+        #[cfg(windows)]
+        {
+            Command::new("cmd.exe")
+                .args(["/C", "gemini", "--version"])
+                .creation_flags(CREATE_NO_WINDOW)
+                .output()
+                .await
+        }
+        #[cfg(not(windows))]
+        {
+            Command::new("sh")
+                .args(["-lc", "gemini --version"])
+                .output()
+                .await
+        }
+    };
+    if let Ok(output) = version_output {
+        println!(
+            "🚀 YOLO-DEBUG: Desktop app CLI version: {}",
+            String::from_utf8_lossy(&output.stdout)
+        );
+    } else {
+        println!("🚀 YOLO-DEBUG: Failed to get CLI version");
+    }
+
+    // Check which gemini executable is being used
+    println!("🚀 YOLO-DEBUG: Testing which gemini executable...");
+    let which_output = {
+        #[cfg(windows)]
+        {
+            Command::new("cmd.exe")
+                .args(["/C", "where", "gemini"])
+                .creation_flags(CREATE_NO_WINDOW)
+                .output()
+                .await
+        }
+        #[cfg(not(windows))]
+        {
+            Command::new("sh")
+                .args(["-lc", "which gemini"])
+                .output()
+                .await
+        }
+    };
+    if let Ok(output) = which_output {
+        println!(
+            "🚀 YOLO-DEBUG: Desktop app gemini path: {}",
+            String::from_utf8_lossy(&output.stdout)
+        );
+        let paths = String::from_utf8_lossy(&output.stdout);
+        let first_path = paths.lines().next().unwrap_or("unknown");
+        println!(
+            "🚀 YOLO-DEBUG: First gemini executable (the one that will be used): {}",
+            first_path
+        );
+    } else {
+        println!("🚀 YOLO-DEBUG: Failed to get gemini path");
+    }
+
+    // Test if the first gemini supports --yolo --experimental-acp
+    println!("🚀 YOLO-DEBUG: Testing if first gemini supports --help...");
+    let help_output = {
+        #[cfg(windows)]
+        {
+            Command::new("cmd.exe")
+                .args(["/C", "gemini", "--help"])
+                .creation_flags(CREATE_NO_WINDOW)
+                .output()
+                .await
+        }
+        #[cfg(not(windows))]
+        {
+            Command::new("sh")
+                .args(["-lc", "gemini --help"])
+                .output()
+                .await
+        }
+    };
+    if let Ok(output) = help_output {
+        let help_text = String::from_utf8_lossy(&output.stdout);
+        let has_yolo = help_text.contains("yolo") || help_text.contains("YOLO");
+        let has_acp = help_text.contains("experimental-acp") || help_text.contains("acp");
+        println!(
+            "🚀 YOLO-DEBUG: First gemini supports --yolo: {}, supports --experimental-acp: {}",
+            has_yolo, has_acp
+        );
+        if !has_yolo || !has_acp {
+            println!(
+                "🚀 YOLO-DEBUG: ⚠️  PROBLEM FOUND: This gemini executable doesn't support YOLO/ACP flags!"
+            );
+        }
+    } else {
+        println!("🚀 YOLO-DEBUG: Failed to get gemini help");
+    }
     let mut child = cmd.spawn().map_err(|e| {
         let cmd_name = if is_qwen { "qwen" } else { "gemini" };
         println!("❌ [HANDSHAKE] Failed to spawn {cmd_name} process: {e}");
@@ -495,19 +632,44 @@ pub async fn initialize_session<E: EventEmitter + 'static>(
 
     // { "jsonrpc": "2.0", "id": 1, "method": "initialize", "params": { "protocolVersion": 1, "clientCapabilities": { "fs": { "readTextFile": true, "writeTextFile": true } } } }
 
-    let init_response = send_jsonrpc_request(
-        &init_request,
-        &mut stdin,
-        &mut reader,
-        &session_id,
-        &emitter,
-        &rpc_logger,
-    )
-    .await
-    .map_err(|e| {
-        println!("❌ [HANDSHAKE] Initialize request failed: {e}");
-        e
-    })?;
+    // The initialize message may end up getting sent before Gemini has fully started up, so we'll
+    // loop and sleep for a short time until we get a JSON response back from Gemini.
+    let init_response;
+    let mut retries = 0;
+    loop {
+        retries += 1;
+        if retries == 5 {
+            return Err(BackendError::SessionInitFailed(
+                "Max number of retries reached".to_string(),
+            ));
+        }
+        let init_response_result = send_jsonrpc_request(
+            &init_request,
+            &mut stdin,
+            &mut reader,
+            &session_id,
+            &emitter,
+            &rpc_logger,
+        )
+        .await
+        .map_err(|e| {
+            println!("❌ [HANDSHAKE] Initialize request failed: {e}");
+            e
+        });
+
+        // `None` indicates that we haven't gotten any JSON response from Gemini yet.
+        match init_response_result {
+            Ok(None) => {
+                println!("No response received yet; sending again");
+                sleep(Duration::from_millis(500)).await;
+            }
+            Ok(Some(res)) => {
+                init_response = res;
+                break;
+            }
+            Err(e) => return Err(e),
+        }
+    }
 
     let _init_result: InitializeResult =
         serde_json::from_value(init_response.result.unwrap_or_default()).map_err(|e| {
@@ -618,11 +780,16 @@ pub async fn initialize_session<E: EventEmitter + 'static>(
 
     let session_response = session_response?;
 
-    let session_result: SessionNewResult =
-        serde_json::from_value(session_response.result.unwrap_or_default()).map_err(|e| {
+    let session_result: SessionNewResult = if let Some(result) = session_response {
+        serde_json::from_value(result.result.unwrap_or_default()).map_err(|e| {
             println!("❌ [HANDSHAKE] Failed to parse session result: {e}");
             BackendError::SessionInitFailed(format!("Failed to parse session result: {e}"))
-        })?;
+        })?
+    } else {
+        return Err(BackendError::SessionInitFailed(
+            "Failed to initialize session".to_string(),
+        ));
+    };
 
     println!(
         "✅ [HANDSHAKE] Step 3/3: ACP session created successfully with ID: {}",
@@ -1025,8 +1192,12 @@ async fn handle_cli_output_line(
                                 kind,
                             } => {
                                 println!(
-                                    "🔧 [EDIT-DEBUG] Backend received ToolCall from CLI: tool_call_id={tool_call_id}, status={status:?}, title={title}"
+                                    "🚀 YOLO-DEBUG: Backend received ToolCall from CLI: tool_call_id={tool_call_id}, status={status:?}, title={title}"
                                 );
+                                println!(
+                                    "🚀 YOLO-DEBUG: In YOLO mode, this should execute without permission requests!"
+                                );
+                                println!("🚀 YOLO-DEBUG: ToolCall kind: {:?}", kind);
 
                                 // Emit pure ACP SessionUpdate event - no legacy conversion
                                 let emit_result = event_tx.send(InternalEvent::AcpSessionUpdate {
@@ -1081,12 +1252,13 @@ async fn handle_cli_output_line(
                     }
                 }
                 "session/request_permission" => {
-                    println!("🔔 BACKEND: Received session/request_permission from CLI");
-                    println!("🔔 BACKEND: JSON value: {json_value:?}");
+                    println!("🔔 YOLO-DEBUG: Received session/request_permission from CLI");
+                    println!("🔔 YOLO-DEBUG: This should NOT happen in YOLO mode!");
+                    println!("🔔 YOLO-DEBUG: JSON value: {json_value:?}");
                     // First try to parse and log what fails
                     let params_value = json_value.get("params").cloned().unwrap_or_default();
                     println!(
-                        "🔔 BACKEND: Trying to parse params: {}",
+                        "🔔 YOLO-DEBUG: Trying to parse params: {}",
                         serde_json::to_string_pretty(&params_value)
                             .unwrap_or("failed to stringify".to_string())
                     );
@@ -1095,11 +1267,15 @@ async fn handle_cli_output_line(
                         serde_json::from_value::<SessionRequestPermissionParams>(params_value)
                         && let Some(id) = json_value.get("id").and_then(|i| i.as_u64())
                     {
-                        println!("🔔 BACKEND: Successfully parsed permission request with id={id}");
                         println!(
-                            "🔔 BACKEND: Tool call ID in request: {}",
+                            "🔔 YOLO-DEBUG: Successfully parsed permission request with id={id}"
+                        );
+                        println!("🔔 YOLO-DEBUG: THIS SHOULD NOT HAPPEN IN YOLO MODE!");
+                        println!(
+                            "🔔 YOLO-DEBUG: Tool call ID in request: {}",
                             params.tool_call.tool_call_id
                         );
+                        println!("🔔 YOLO-DEBUG: Request details: {:?}", params);
                         // Emit pure ACP permission request - no legacy conversion
                         let _ = event_tx.send(InternalEvent::AcpPermissionRequest {
                             session_id: session_id.to_string(),
@@ -1107,7 +1283,7 @@ async fn handle_cli_output_line(
                             request: params,
                         });
                         println!(
-                            "🔔 BACKEND: Sent InternalEvent::AcpPermissionRequest to event_tx"
+                            "🔔 YOLO-DEBUG: Sent InternalEvent::AcpPermissionRequest to event_tx (THIS IS THE PROBLEM!)"
                         );
                     } else {
                         // Try to get the specific parsing error

--- a/crates/server/src/main.rs
+++ b/crates/server/src/main.rs
@@ -407,6 +407,9 @@ async fn start_session(request: Json<StartSessionRequest>, state: &State<AppStat
         "🎯 [SESSION-REQUEST] Gemini auth present: {}",
         req.gemini_auth.is_some()
     );
+    if let Some(ref auth) = req.gemini_auth {
+        println!("🔔 YOLO-DEBUG Server: Received gemini_auth: method={}, yolo={:?}", auth.method, auth.yolo);
+    }
 
     let backend = state.backend.lock().await;
 
@@ -464,6 +467,12 @@ async fn send_message(request: Json<SendMessageRequest>, state: &State<AppState>
         .any(|status| status.conversation_id == req.session_id && status.is_alive);
 
     if !session_exists && req.backend_config.is_some() {
+        println!("🚀 YOLO-DEBUG: send_message creating new session for backend_config");
+        if let Some(ref auth) = req.gemini_auth {
+            println!("🚀 YOLO-DEBUG: send_message gemini_auth: {:?}", auth);
+        } else {
+            println!("🚀 YOLO-DEBUG: send_message NO gemini_auth provided!");
+        }
         let model = req
             .model
             .unwrap_or_else(|| "gemini-2.0-flash-exp".to_string());

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -212,7 +212,9 @@ function RootLayoutContent() {
               geminiConfig.authMethod === "vertex-ai"
                 ? geminiConfig.vertexLocation
                 : undefined,
+            yolo: geminiConfig.yolo || false,
           };
+          console.log("🔔 YOLO-DEBUG Frontend: Sending gemini_auth config:", JSON.stringify(sessionParams.gemini_auth, null, 2));
         }
 
         await api.invoke("start_session", sessionParams);

--- a/frontend/src/components/conversation/ConversationList.tsx
+++ b/frontend/src/components/conversation/ConversationList.tsx
@@ -467,6 +467,23 @@ export function ConversationList({
                   {t("conversations.cloudShellInfo")}
                 </p>
               )}
+
+              {/* YOLO Mode Checkbox */}
+              <div className="flex items-center space-x-2">
+                <Checkbox
+                  id="yolo-checkbox"
+                  checked={geminiConfig.yolo || false}
+                  onCheckedChange={(checked) => {
+                    updateGeminiConfig({ yolo: checked === true });
+                  }}
+                />
+                <label
+                  htmlFor="yolo-checkbox"
+                  className="text-sm font-medium text-gray-700 dark:text-gray-300 cursor-pointer"
+                >
+                  {t("conversations.yoloMode")}
+                </label>
+              </div>
             </div>
           </>
         )}

--- a/frontend/src/hooks/useConversationEvents.ts
+++ b/frontend/src/hooks/useConversationEvents.ts
@@ -441,21 +441,30 @@ export const useConversationEvents = (
                             Array.isArray(update.content) &&
                             update.content.length > 0
                           ) {
-                            const contentItem = update.content[0];
-                            if (
-                              contentItem.type === "content" &&
-                              contentItem.content.type === "text"
-                            ) {
-                              msgPart.toolCall.result =
-                                contentItem.content.text;
+                            // Use the existing convertAcpContentToLegacy function to properly handle diff content
+                            const legacyResult = convertAcpContentToLegacy(update.content);
+                            console.log(
+                              "🔧 [EDIT-DEBUG] Converted ACP content:",
+                              legacyResult
+                            );
+                            
+                            // Convert LegacyResult to ToolCallResult format
+                            if (legacyResult.type === "diff") {
+                              msgPart.toolCall.result = {
+                                file_path: legacyResult.path,
+                                old_string: legacyResult.oldText,
+                                new_string: legacyResult.newText,
+                                success: true,
+                              };
                               console.log(
-                                "🔧 [EDIT-DEBUG] Updated tool call with text result:",
-                                contentItem.content.text.substring(0, 100)
+                                "🔧 [EDIT-DEBUG] Updated tool call with diff result for:",
+                                legacyResult.path
                               );
-                            } else if (contentItem.type === "diff") {
-                              // For diff content, just store as text with formatting
-                              const diffResult = `Diff for ${contentItem.path}:\nOld: ${contentItem.old_text}\nNew: ${contentItem.new_text}`;
-                              msgPart.toolCall.result = diffResult;
+                            } else if (legacyResult.type === "generic") {
+                              msgPart.toolCall.result = legacyResult.newText || "";
+                              console.log(
+                                "🔧 [EDIT-DEBUG] Updated tool call with generic text result"
+                              );
                             }
                           } else if (typeof update.content === "string") {
                             msgPart.toolCall.result = update.content;

--- a/frontend/src/hooks/useMessageHandler.ts
+++ b/frontend/src/hooks/useMessageHandler.ts
@@ -192,7 +192,9 @@ export const useMessageHandler = ({
               geminiConfig.authMethod === "vertex-ai"
                 ? geminiConfig.vertexLocation
                 : undefined,
+            yolo: geminiConfig.yolo || false,
           };
+          console.log("🔔 YOLO-DEBUG useMessageHandler: Sending gemini_auth config:", JSON.stringify(sessionParams.gemini_auth, null, 2));
         }
 
         // Initialize session (it will skip if already initialized)

--- a/frontend/src/i18n/locales/en/translation.json
+++ b/frontend/src/i18n/locales/en/translation.json
@@ -155,6 +155,7 @@
     "locationRegion": "Location/Region",
     "oauthLimits": "1000 free requests per day, 60 free requests per minute.",
     "cloudShellInfo": "This method works automatically in Google Cloud Shell environments",
+    "yoloMode": "YOLO Mode",
     "stillWaiting": "Still waitin'...",
     "messageCount": "{{count}} message",
     "messageCount_other": "{{count}} messages"

--- a/frontend/src/i18n/locales/zh-CN/translation.json
+++ b/frontend/src/i18n/locales/zh-CN/translation.json
@@ -155,6 +155,7 @@
     "locationRegion": "位置/区域",
     "oauthLimits": "每天 1000 次免费请求，每分钟 60 次免费请求。",
     "cloudShellInfo": "此方法在 Google Cloud Shell 环境中自动工作",
+    "yoloMode": "YOLO 模式",
     "stillWaiting": "仍在等待...",
     "messageCount": "{{count}} 条消息",
     "messageCount_other": "{{count}} 条消息"

--- a/frontend/src/i18n/locales/zh-TW/translation.json
+++ b/frontend/src/i18n/locales/zh-TW/translation.json
@@ -155,6 +155,7 @@
     "locationRegion": "位置/區域",
     "oauthLimits": "每日 1000 次免費請求，每分鐘 60 次免費請求。",
     "cloudShellInfo": "此方式在 Google Cloud Shell 環境中自動運作",
+    "yoloMode": "YOLO 模式",
     "stillWaiting": "仍在等待中...",
     "messageCount": "{{count}} 則訊息",
     "messageCount_other": "{{count}} 則訊息"

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -163,6 +163,7 @@ export const api = {
               api_key?: string;
               vertex_project?: string;
               vertex_location?: string;
+              yolo?: boolean;
             };
           };
           return webApi.start_session(

--- a/frontend/src/lib/webApi.ts
+++ b/frontend/src/lib/webApi.ts
@@ -21,6 +21,7 @@ interface StartSessionRequest {
     api_key?: string;
     vertex_project?: string;
     vertex_location?: string;
+    yolo?: boolean;
   };
 }
 
@@ -117,6 +118,7 @@ export const webApi = {
       api_key?: string;
       vertex_project?: string;
       vertex_location?: string;
+      yolo?: boolean;
     }
   ): Promise<void> {
     const request: StartSessionRequest = {

--- a/frontend/src/types/backend.ts
+++ b/frontend/src/types/backend.ts
@@ -16,6 +16,7 @@ export interface GeminiConfig {
   // Vertex AI specific fields
   vertexProject?: string;
   vertexLocation?: string;
+  yolo?: boolean;
 }
 
 export interface QwenConfig {
@@ -54,6 +55,7 @@ export interface GeminiAuth {
   api_key?: string;
   vertex_project?: string;
   vertex_location?: string;
+  yolo?: boolean;
 }
 
 export interface BackendConfigParams {


### PR DESCRIPTION
- Extend GeminiAuthConfig, GeminiAuth, and related request types with an optional `yolo` boolean flag.

- Update session initialization to conditionally include `--yolo` in the Gemini CLI command, add a 5‑second read timeout using `tokio::select`, and implement a retry loop for the initialize request.

- Change `send_jsonrpc_request` to return `Option<JsonRpcResponse>` and adjust all callers to handle the `None` case.

- Add extensive debug logging (YOLO‑DEBUG) for command construction, version checks, and permission handling.

- Introduce a YOLO mode checkbox in the conversation UI and corresponding translation strings for English, Chinese (Simplified & Traditional).

- Propagate the `yolo` flag through the frontend API layer (`api.ts`, `webApi.ts`), type definitions, and server request handling, including logging of received values.

BREAKING CHANGE: `send_jsonrpc_request` now returns `Option<JsonRpcResponse>`; callers must handle the possibility of `None` when no JSON response is received.