### PR TITLE
fix(acp): add back client capabilities to initialize request

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -431,7 +431,10 @@ The application implements the complete Agent Communication Protocol specificati
 // Initialize session
 method: "initialize"
 params: {
-  protocolVersion: 1
+  protocolVersion: 1,
+  clientCapabilities: {
+    fs: { readTextFile: boolean, writeTextFile: boolean }
+  }
 }
 ```
 
@@ -486,11 +489,11 @@ export interface API {
   send_message(params: MessageParams): Promise<void>;
   get_process_statuses(): Promise<ProcessStatus[]>;
   kill_process(params: { conversationId: string }): Promise<void>;
-  
+
   // Tool call confirmation
   send_tool_call_confirmation_response(params: ConfirmationParams): Promise<void>;
   execute_confirmed_command(params: { command: string }): Promise<string>;
-  
+
   // Project and chat management
   get_recent_chats(): Promise<RecentChat[]>;
   search_chats(params: SearchParams): Promise<SearchResult[]>;
@@ -498,7 +501,7 @@ export interface API {
   get_project_discussions(params: { projectId: string }): Promise<Discussion[]>;
   list_enriched_projects(): Promise<EnrichedProject[]>;
   get_project(params: ProjectParams): Promise<EnrichedProject>;
-  
+
   // File system operations
   validate_directory(params: { path: string }): Promise<boolean>;
   is_home_directory(params: { path: string }): Promise<boolean>;
@@ -506,7 +509,7 @@ export interface API {
   get_parent_directory(params: { path: string }): Promise<string | null>;
   list_directory_contents(params: { path: string }): Promise<DirEntry[]>;
   list_volumes(): Promise<DirEntry[]>;
-  
+
   // Utilities
   generate_conversation_title(params: TitleParams): Promise<string>;
 }

--- a/crates/backend/src/acp/mod.rs
+++ b/crates/backend/src/acp/mod.rs
@@ -8,6 +8,23 @@ use serde::{Deserialize, Serialize};
 pub struct InitializeParams {
     #[serde(rename = "protocolVersion")]
     pub protocol_version: u32,
+    #[serde(rename = "clientCapabilities")]
+    pub client_capabilities: ClientCapabilities,
+}
+
+/// Client capabilities for ACP protocol
+#[derive(Debug, Serialize, Deserialize)]
+pub struct ClientCapabilities {
+    pub fs: FileSystemCapabilities,
+}
+
+/// File system capabilities
+#[derive(Debug, Serialize, Deserialize)]
+pub struct FileSystemCapabilities {
+    #[serde(rename = "readTextFile")]
+    pub read_text_file: bool,
+    #[serde(rename = "writeTextFile")]
+    pub write_text_file: bool,
 }
 
 /// Initialize response result
@@ -295,11 +312,23 @@ mod tests {
     fn test_initialize_params_serialization() {
         let params = InitializeParams {
             protocol_version: 1,
+            client_capabilities: ClientCapabilities {
+                fs: FileSystemCapabilities {
+                    read_text_file: false,
+                    write_text_file: false,
+                },
+            },
         };
 
         let serialized = serde_json::to_value(&params).unwrap();
         let expected = json!({
-            "protocolVersion": 1
+            "protocolVersion": 1,
+            "clientCapabilities": {
+                "fs": {
+                    "readTextFile": false,
+                    "writeTextFile": false
+                }
+            }
         });
 
         assert_eq!(serialized, expected);
@@ -525,10 +554,20 @@ mod tests {
         // 1. Initialize
         let init_params = InitializeParams {
             protocol_version: 1,
+            client_capabilities: ClientCapabilities {
+                fs: FileSystemCapabilities {
+                    read_text_file: false,
+                    write_text_file: false,
+                },
+            },
         };
 
         let init_serialized = serde_json::to_value(&init_params).unwrap();
         assert_eq!(init_serialized["protocolVersion"], 1);
+        assert_eq!(
+            init_serialized["clientCapabilities"]["fs"]["readTextFile"],
+            true
+        );
 
         // 2. Authenticate
         let auth_params = AuthenticateParams {

--- a/crates/backend/src/session/mod.rs
+++ b/crates/backend/src/session/mod.rs
@@ -28,9 +28,9 @@ pub struct GeminiAuthConfig {
 }
 
 use crate::acp::{
-    AuthenticateParams, ContentBlock, InitializeParams, InitializeResult, SessionNewParams,
-    SessionNewResult, SessionPromptResult, SessionRequestPermissionParams, SessionUpdate,
-    SessionUpdateParams,
+    AuthenticateParams, ClientCapabilities, ContentBlock, FileSystemCapabilities, InitializeParams,
+    InitializeResult, SessionNewParams, SessionNewResult, SessionPromptResult,
+    SessionRequestPermissionParams, SessionUpdate, SessionUpdateParams,
 };
 use crate::cli::StreamAssistantMessageChunkParams;
 use crate::events::{
@@ -610,6 +610,12 @@ pub async fn initialize_session<E: EventEmitter + 'static>(
     println!("🤝 [HANDSHAKE] Step 1/3: Sending initialize request");
     let init_params = InitializeParams {
         protocol_version: 1,
+        client_capabilities: ClientCapabilities {
+            fs: FileSystemCapabilities {
+                read_text_file: false,
+                write_text_file: false,
+            },
+        },
     };
     println!("🤝 [HANDSHAKE] Initialize params: protocol_version=1");
 
@@ -623,7 +629,7 @@ pub async fn initialize_session<E: EventEmitter + 'static>(
         })?,
     };
 
-    // { "jsonrpc": "2.0", "id": 1, "method": "initialize", "params": { "protocolVersion": 1 } }
+    // { "jsonrpc": "2.0", "id": 1, "method": "initialize", "params": { "protocolVersion": 1, "clientCapabilities": { "fs": { "readTextFile": true, "writeTextFile": true } } } }
 
     // The initialize message may end up getting sent before Gemini has fully started up, so we'll
     // loop and sleep for a short time until we get a JSON response back from Gemini.


### PR DESCRIPTION
- Introduce `ClientCapabilities` and `FileSystemCapabilities` structs

- Extend `InitializeParams` with required `clientCapabilities` field

- Update session initialization to include default file system capabilities

- Adjust documentation and tests to reflect new initialization schema

BREAKING CHANGE: `InitializeParams` now requires `clientCapabilities`, breaking existing clients that only send `protocolVersion`.