### PR TITLE
fix(session): prevent dual CLI execution when switching backends

### DIFF
--- a/crates/backend/src/lib.rs
+++ b/crates/backend/src/lib.rs
@@ -198,8 +198,12 @@ impl<E: EventEmitter + 'static> GeminiBackend<E> {
         backend_config: Option<QwenConfig>,
         gemini_auth: Option<GeminiAuthConfig>,
     ) -> Result<()> {
-        let requested_backend = if backend_config.is_some() { "qwen" } else { "gemini" };
-        
+        let requested_backend = if backend_config.is_some() {
+            "qwen"
+        } else {
+            "gemini"
+        };
+
         {
             let processes = self.session_manager.get_processes();
             if let Ok(guard) = processes.lock()
@@ -208,14 +212,21 @@ impl<E: EventEmitter + 'static> GeminiBackend<E> {
             {
                 // Check if the existing session is using the same backend type
                 if existing.backend_type == requested_backend {
-                    println!("🔄 [SESSION-CHECK] Existing {} session found for {}, reusing", requested_backend, session_id);
+                    println!(
+                        "🔄 [SESSION-CHECK] Existing {} session found for {}, reusing",
+                        requested_backend, session_id
+                    );
                     return Ok(());
                 } else {
                     // Different backend requested - kill the existing session first
-                    println!("🔄 [SESSION-CHECK] Backend switch detected: {} -> {} for session {}", 
-                        existing.backend_type, requested_backend, session_id);
-                    println!("🔄 [SESSION-CHECK] Killing existing {} session before starting {}", 
-                        existing.backend_type, requested_backend);
+                    println!(
+                        "🔄 [SESSION-CHECK] Backend switch detected: {} -> {} for session {}",
+                        existing.backend_type, requested_backend, session_id
+                    );
+                    println!(
+                        "🔄 [SESSION-CHECK] Killing existing {} session before starting {}",
+                        existing.backend_type, requested_backend
+                    );
                     // Drop the guard before calling kill_process to avoid deadlock
                     drop(guard);
                     self.session_manager.kill_process(&session_id)?;

--- a/crates/backend/src/lib.rs
+++ b/crates/backend/src/lib.rs
@@ -189,7 +189,7 @@ impl<E: EventEmitter + 'static> GeminiBackend<E> {
         }
     }
 
-    /// Initialize a new Gemini CLI session
+    /// Initialize a new CLI session (Gemini or Qwen)
     pub async fn initialize_session(
         &self,
         session_id: String,
@@ -198,13 +198,28 @@ impl<E: EventEmitter + 'static> GeminiBackend<E> {
         backend_config: Option<QwenConfig>,
         gemini_auth: Option<GeminiAuthConfig>,
     ) -> Result<()> {
+        let requested_backend = if backend_config.is_some() { "qwen" } else { "gemini" };
+        
         {
             let processes = self.session_manager.get_processes();
             if let Ok(guard) = processes.lock()
                 && let Some(existing) = guard.get(&session_id)
                 && existing.is_alive
             {
-                return Ok(());
+                // Check if the existing session is using the same backend type
+                if existing.backend_type == requested_backend {
+                    println!("🔄 [SESSION-CHECK] Existing {} session found for {}, reusing", requested_backend, session_id);
+                    return Ok(());
+                } else {
+                    // Different backend requested - kill the existing session first
+                    println!("🔄 [SESSION-CHECK] Backend switch detected: {} -> {} for session {}", 
+                        existing.backend_type, requested_backend, session_id);
+                    println!("🔄 [SESSION-CHECK] Killing existing {} session before starting {}", 
+                        existing.backend_type, requested_backend);
+                    // Drop the guard before calling kill_process to avoid deadlock
+                    drop(guard);
+                    self.session_manager.kill_process(&session_id)?;
+                }
             }
         }
 

--- a/crates/backend/src/session/mod.rs
+++ b/crates/backend/src/session/mod.rs
@@ -763,7 +763,11 @@ pub async fn initialize_session<E: EventEmitter + 'static>(
             anyhow::anyhow!("Session initialization failed: Failed to lock processes")
         })?;
 
-        let backend_type = if backend_config.is_some() { "qwen" } else { "gemini" };
+        let backend_type = if backend_config.is_some() {
+            "qwen"
+        } else {
+            "gemini"
+        };
         let persistent_session = PersistentSession {
             conversation_id: session_id.clone(),
             acp_session_id: Some(session_result.session_id.clone()),
@@ -782,10 +786,16 @@ pub async fn initialize_session<E: EventEmitter + 'static>(
         };
 
         processes.insert(session_id.clone(), persistent_session);
-        println!("💾 [HANDSHAKE] {} session stored successfully - marking as ALIVE", backend_type.to_uppercase());
+        println!(
+            "💾 [HANDSHAKE] {} session stored successfully - marking as ALIVE",
+            backend_type.to_uppercase()
+        );
         println!(
             "💾 [HANDSHAKE] Session details: conversation_id={}, backend={}, acp_session_id={}, pid={:?}, is_alive=true",
-            session_id, backend_type.to_uppercase(), session_result.session_id, pid
+            session_id,
+            backend_type.to_uppercase(),
+            session_result.session_id,
+            pid
         );
     }
 


### PR DESCRIPTION
Add backend_type field to `PersistentSession` and `ProcessStatus` to track which CLI (Gemini CLI/Qwen Code) is running. Update session existence check to consider backend compatibility and kill existing sessions when switching between different backends.

This resolves the issue where switching from Gemini to Qwen Code would result in both CLIs running simultaneously.