### PR TITLE
feat(mcp): add support for MCP server calls

### DIFF
--- a/crates/backend/src/lib.rs
+++ b/crates/backend/src/lib.rs
@@ -472,6 +472,8 @@ impl<E: EventEmitter + 'static> GeminiBackend<E> {
             tool_call_id: tool_call_id.clone(),
             status: ToolCallStatus::Completed,
             content: content_items,
+            server_name: None,
+            tool_name: None,
         };
 
         // Emit ACP session update event - use the conversation_id (frontend conversation ID), not ACP session ID

--- a/crates/backend/src/session/mod.rs
+++ b/crates/backend/src/session/mod.rs
@@ -1161,6 +1161,8 @@ async fn handle_cli_output_line(
                                 content,
                                 locations,
                                 kind,
+                                server_name,
+                                tool_name,
                             } => {
                                 println!(
                                     "🚀 YOLO-DEBUG: Backend received ToolCall from CLI: tool_call_id={tool_call_id}, status={status:?}, title={title}"
@@ -1180,6 +1182,8 @@ async fn handle_cli_output_line(
                                         content: content.clone(),
                                         locations: locations.clone(),
                                         kind: kind.clone(),
+                                        server_name: server_name.clone(),
+                                        tool_name: tool_name.clone(),
                                     },
                                 });
 
@@ -1197,6 +1201,8 @@ async fn handle_cli_output_line(
                                 tool_call_id,
                                 status,
                                 content,
+                                server_name,
+                                tool_name,
                             } => {
                                 println!(
                                     "🔧 [EDIT-DEBUG] Backend received ToolCallUpdate from CLI: tool_call_id={tool_call_id}, status={status:?}"
@@ -1213,6 +1219,8 @@ async fn handle_cli_output_line(
                                         tool_call_id: tool_call_id.clone(),
                                         status: status.clone(),
                                         content: content.clone(),
+                                        server_name: server_name.clone(),
+                                        tool_name: tool_name.clone(),
                                     },
                                 });
                                 println!(

--- a/frontend/src/components/mcp/McpPermissionCompact.tsx
+++ b/frontend/src/components/mcp/McpPermissionCompact.tsx
@@ -1,0 +1,223 @@
+import { useState } from "react";
+import { ChevronRight, Wrench, Check, X } from "lucide-react";
+import { Button } from "../ui/button";
+import { McpPermissionRequest, McpPermissionOption } from "../../types";
+
+interface McpPermissionCompactProps {
+  request: McpPermissionRequest;
+  onPermissionResponse: (optionId: string) => void;
+}
+
+export function McpPermissionCompact({
+  request,
+  onPermissionResponse,
+}: McpPermissionCompactProps) {
+  const [isExpanded, setIsExpanded] = useState(false);
+
+  // Use direct server and tool names from request if available, otherwise parse from title
+  const serverName =
+    request.toolCall.serverName ||
+    (() => {
+      const match = request.toolCall.title.match(/\((.+?) MCP Server\)$/);
+      return match ? match[1] : "MCP Server";
+    })();
+
+  const toolName =
+    request.toolCall.toolName ||
+    (() => {
+      const match = request.toolCall.title.match(/^([^(]+)/);
+      return match ? match[1].trim() : "Unknown Tool";
+    })();
+
+  // Group options by type for compact display
+  const serverOptions = request.options.filter((opt) =>
+    opt.optionId.includes("server")
+  );
+  const toolOptions = request.options.filter((opt) =>
+    opt.optionId.includes("tool")
+  );
+  const allowOnceOptions = request.options.filter(
+    (opt) => opt.kind === "allow_once"
+  );
+  const rejectOptions = request.options.filter(
+    (opt) => opt.kind === "reject_once"
+  );
+
+  const getButtonStyle = (option: McpPermissionOption) => {
+    if (option.kind === "allow_always")
+      return "h-6 w-6 p-0 bg-green-600 hover:bg-green-700 text-white";
+    if (option.kind === "allow_once")
+      return "h-6 w-6 p-0 bg-green-600 hover:bg-green-700 text-white";
+    if (option.kind === "reject_once")
+      return "h-6 w-6 p-0 bg-red-600 hover:bg-red-700 text-white";
+    return "h-6 w-6 p-0";
+  };
+
+  const getButtonIcon = (option: McpPermissionOption) => {
+    if (option.kind.includes("allow")) return <Check className="h-3 w-3" />;
+    if (option.kind.includes("reject")) return <X className="h-3 w-3" />;
+    return <Wrench className="h-3 w-3" />;
+  };
+
+  return (
+    <div className="mt-4">
+      {/* Compact header matching other tool renderers */}
+      <div
+        className="flex items-center gap-2 text-sm px-2 py-1 cursor-pointer hover:bg-muted/50 rounded-lg transition-colors"
+        onClick={() => setIsExpanded(!isExpanded)}
+      >
+        <Wrench className="h-4 w-4 text-blue-500" />
+        <span>Permission required for </span>
+        <span className="font-medium">{toolName}</span>
+        <span className="text-muted-foreground">from {serverName}</span>
+
+        {/* Compact permission buttons in header */}
+        <div
+          className="ml-auto flex items-center gap-1"
+          onClick={(e) => e.stopPropagation()}
+        >
+          {/* Always allow server (green) */}
+          {serverOptions
+            .filter((opt) => opt.kind === "allow_always")
+            .map((option) => (
+              <Button
+                key={option.optionId}
+                size="sm"
+                variant="default"
+                className={getButtonStyle(option)}
+                onClick={() => onPermissionResponse(option.optionId)}
+                title={option.name}
+              >
+                {getButtonIcon(option)}
+              </Button>
+            ))}
+
+          {/* Always allow tool (green) */}
+          {toolOptions
+            .filter((opt) => opt.kind === "allow_always")
+            .map((option) => (
+              <Button
+                key={option.optionId}
+                size="sm"
+                variant="default"
+                className={getButtonStyle(option)}
+                onClick={() => onPermissionResponse(option.optionId)}
+                title={option.name}
+              >
+                {getButtonIcon(option)}
+              </Button>
+            ))}
+
+          {/* Allow once (blue) */}
+          {allowOnceOptions.map((option) => (
+            <Button
+              key={option.optionId}
+              size="sm"
+              variant="default"
+              className={getButtonStyle(option)}
+              onClick={() => onPermissionResponse(option.optionId)}
+              title={option.name}
+            >
+              {getButtonIcon(option)}
+            </Button>
+          ))}
+
+          {/* Reject (red) */}
+          {rejectOptions.map((option) => (
+            <Button
+              key={option.optionId}
+              size="sm"
+              variant="default"
+              className={getButtonStyle(option)}
+              onClick={() => onPermissionResponse(option.optionId)}
+              title={option.name}
+            >
+              {getButtonIcon(option)}
+            </Button>
+          ))}
+        </div>
+
+        <ChevronRight
+          className={`h-4 w-4 text-muted-foreground transition-transform ${
+            isExpanded ? "rotate-90" : ""
+          }`}
+        />
+      </div>
+
+      {/* Expandable detailed view */}
+      {isExpanded && (
+        <div className="ml-6 mt-2 text-sm space-y-2 border-l-2 border-border pl-4">
+          <div className="text-muted-foreground">
+            <span className="font-medium text-foreground">
+              {serverName} MCP Server
+            </span>{" "}
+            wants to execute{" "}
+            <span className="font-medium text-foreground">{toolName}</span>
+          </div>
+
+          {/* Detailed permission options */}
+          <div className="space-y-1">
+            {serverOptions.length > 0 && (
+              <div className="flex items-center gap-2 text-xs">
+                <span className="text-green-700">🟢 Server-level:</span>
+                {serverOptions.map((option) => (
+                  <Button
+                    key={option.optionId}
+                    size="sm"
+                    variant="default"
+                    className="h-5 px-2 text-xs bg-green-600 hover:bg-green-700 text-white"
+                    onClick={() => onPermissionResponse(option.optionId)}
+                  >
+                    {option.name}
+                  </Button>
+                ))}
+              </div>
+            )}
+
+            {toolOptions.length > 0 && (
+              <div className="flex items-center gap-2 text-xs">
+                <span className="text-green-700">🔧 Tool-level:</span>
+                {toolOptions.map((option) => (
+                  <Button
+                    key={option.optionId}
+                    size="sm"
+                    variant="default"
+                    className="h-5 px-2 text-xs bg-green-600 hover:bg-green-700 text-white"
+                    onClick={() => onPermissionResponse(option.optionId)}
+                  >
+                    {option.name}
+                  </Button>
+                ))}
+              </div>
+            )}
+
+            <div className="flex items-center gap-2 text-xs">
+              {allowOnceOptions.map((option) => (
+                <Button
+                  key={option.optionId}
+                  size="sm"
+                  variant="default"
+                  className="h-5 px-2 text-xs bg-green-600 hover:bg-green-700 text-white"
+                  onClick={() => onPermissionResponse(option.optionId)}
+                >
+                  {option.name}
+                </Button>
+              ))}
+              {rejectOptions.map((option) => (
+                <Button
+                  key={option.optionId}
+                  size="sm"
+                  variant="default"
+                  className="h-5 px-2 text-xs bg-red-600 hover:bg-red-700 text-white"
+                  onClick={() => onPermissionResponse(option.optionId)}
+                >
+                  {option.name}
+                </Button>
+              ))}
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/mcp/McpPermissionDialog.tsx
+++ b/frontend/src/components/mcp/McpPermissionDialog.tsx
@@ -1,0 +1,232 @@
+import { Card, CardContent, CardHeader, CardTitle } from "../ui/card";
+import { Button } from "../ui/button";
+import { Badge } from "../ui/badge";
+import {
+  Shield,
+  ShieldCheck,
+  Play,
+  X,
+  Server,
+  Wrench,
+  AlertTriangle,
+} from "lucide-react";
+import { McpPermissionRequest, McpPermissionOption } from "../../types";
+
+interface McpPermissionDialogProps {
+  request: McpPermissionRequest;
+  onPermissionResponse: (optionId: string) => void;
+}
+
+export function McpPermissionDialog({
+  request,
+  onPermissionResponse,
+}: McpPermissionDialogProps) {
+  // Use direct server and tool names from request if available, otherwise parse from title
+  const serverName =
+    request.toolCall.serverName ||
+    (() => {
+      const match = request.toolCall.title.match(/\((.+?) MCP Server\)$/);
+      return match ? match[1] : "Unknown Server";
+    })();
+
+  const toolName =
+    request.toolCall.toolName ||
+    (() => {
+      const match = request.toolCall.title.match(/^([^(]+)/);
+      return match ? match[1].trim() : "Unknown Tool";
+    })();
+
+  // Group options by type for better layout
+  const serverOptions = request.options.filter((opt) =>
+    opt.optionId.includes("server")
+  );
+  const toolOptions = request.options.filter((opt) =>
+    opt.optionId.includes("tool")
+  );
+  const oneTimeOptions = request.options.filter(
+    (opt) => opt.kind === "allow_once" || opt.kind === "reject_once"
+  );
+
+  const getOptionIcon = (option: McpPermissionOption) => {
+    if (option.optionId.includes("server"))
+      return <Server className="w-4 h-4" />;
+    if (option.optionId.includes("tool")) return <Wrench className="w-4 h-4" />;
+    if (option.kind === "allow_once") return <Play className="w-4 h-4" />;
+    if (option.kind === "reject_once") return <X className="w-4 h-4" />;
+    return <Shield className="w-4 h-4" />;
+  };
+
+  const getOptionVariant = (option: McpPermissionOption) => {
+    if (option.kind === "allow_always") return "default";
+    if (option.kind === "allow_once") return "secondary";
+    if (option.kind === "reject_once") return "outline";
+    return "secondary";
+  };
+
+  const getOptionStyle = (option: McpPermissionOption) => {
+    if (option.kind === "allow_always")
+      return "bg-green-50 hover:bg-green-100 border-green-200 text-green-800";
+    if (option.kind === "allow_once")
+      return "bg-blue-50 hover:bg-blue-100 border-blue-200 text-blue-800";
+    if (option.kind === "reject_once")
+      return "bg-red-50 hover:bg-red-100 border-red-200 text-red-800";
+    return "";
+  };
+
+  return (
+    <Card className="w-full max-w-2xl mx-auto shadow-lg border-orange-200 bg-gradient-to-br from-orange-50 to-amber-50">
+      <CardHeader className="pb-4">
+        <div className="flex items-center gap-3">
+          <div className="p-2 bg-orange-100 rounded-lg">
+            <Server className="w-6 h-6 text-orange-600" />
+          </div>
+          <div className="flex-1">
+            <CardTitle className="text-lg flex items-center gap-2">
+              <span className="text-orange-800">
+                MCP Tool Permission Request
+              </span>
+              <Badge
+                variant="secondary"
+                className="bg-orange-200 text-orange-800"
+              >
+                {serverName}
+              </Badge>
+            </CardTitle>
+            <p className="text-sm text-muted-foreground mt-1">
+              The{" "}
+              <span className="font-medium text-orange-700">{serverName}</span>{" "}
+              server wants to execute the{" "}
+              <span className="font-medium text-orange-700">{toolName}</span>{" "}
+              tool
+            </p>
+          </div>
+        </div>
+      </CardHeader>
+
+      <CardContent className="space-y-6">
+        {/* Tool Information */}
+        <div className="bg-white/60 rounded-lg p-4 border border-orange-100">
+          <div className="flex items-center gap-2 mb-2">
+            <Wrench className="w-4 h-4 text-orange-600" />
+            <span className="font-medium text-orange-800">Tool Details</span>
+          </div>
+          <div className="text-sm text-gray-700">
+            <p>
+              <span className="font-medium">Name:</span> {toolName}
+            </p>
+            <p>
+              <span className="font-medium">Server:</span> {serverName} MCP
+              Server
+            </p>
+            <p>
+              <span className="font-medium">Status:</span>
+              <Badge variant="outline" className="ml-1 capitalize">
+                {request.toolCall.status}
+              </Badge>
+            </p>
+          </div>
+        </div>
+
+        {/* Permission Warning */}
+        <div className="bg-amber-50 border border-amber-200 rounded-lg p-4">
+          <div className="flex items-start gap-3">
+            <AlertTriangle className="w-5 h-5 text-amber-600 mt-0.5 flex-shrink-0" />
+            <div className="text-sm">
+              <p className="font-medium text-amber-800 mb-1">
+                Permission Required
+              </p>
+              <p className="text-amber-700">
+                This MCP server is requesting permission to execute a tool.
+                Choose how you'd like to proceed:
+              </p>
+            </div>
+          </div>
+        </div>
+
+        {/* Permission Options */}
+        <div className="space-y-4">
+          {/* Always Allow Options */}
+          {(serverOptions.length > 0 || toolOptions.length > 0) && (
+            <div>
+              <h4 className="font-medium text-gray-900 mb-3 flex items-center gap-2">
+                <ShieldCheck className="w-4 h-4 text-green-600" />
+                Always Allow
+              </h4>
+              <div className="grid gap-2">
+                {serverOptions.map((option) => (
+                  <Button
+                    key={option.optionId}
+                    variant="outline"
+                    className={`justify-start h-auto p-4 ${getOptionStyle(option)}`}
+                    onClick={() => onPermissionResponse(option.optionId)}
+                  >
+                    <div className="flex items-center gap-3">
+                      {getOptionIcon(option)}
+                      <div className="text-left">
+                        <div className="font-medium">{option.name}</div>
+                        <div className="text-xs opacity-75">
+                          Trust all tools from {serverName} server
+                        </div>
+                      </div>
+                    </div>
+                  </Button>
+                ))}
+                {toolOptions.map((option) => (
+                  <Button
+                    key={option.optionId}
+                    variant="outline"
+                    className={`justify-start h-auto p-4 ${getOptionStyle(option)}`}
+                    onClick={() => onPermissionResponse(option.optionId)}
+                  >
+                    <div className="flex items-center gap-3">
+                      {getOptionIcon(option)}
+                      <div className="text-left">
+                        <div className="font-medium">{option.name}</div>
+                        <div className="text-xs opacity-75">
+                          Always allow this specific tool
+                        </div>
+                      </div>
+                    </div>
+                  </Button>
+                ))}
+              </div>
+            </div>
+          )}
+
+          {/* One-time Options */}
+          {oneTimeOptions.length > 0 && (
+            <div>
+              <h4 className="font-medium text-gray-900 mb-3 flex items-center gap-2">
+                <Shield className="w-4 h-4 text-blue-600" />
+                One-time Actions
+              </h4>
+              <div className="flex gap-3">
+                {oneTimeOptions.map((option) => (
+                  <Button
+                    key={option.optionId}
+                    variant={getOptionVariant(option)}
+                    className={`flex-1 h-12 ${getOptionStyle(option)}`}
+                    onClick={() => onPermissionResponse(option.optionId)}
+                  >
+                    <div className="flex items-center gap-2">
+                      {getOptionIcon(option)}
+                      <span className="font-medium">{option.name}</span>
+                    </div>
+                  </Button>
+                ))}
+              </div>
+            </div>
+          )}
+        </div>
+
+        {/* Footer Info */}
+        <div className="text-xs text-gray-500 bg-white/40 rounded p-3 border border-orange-100">
+          <p>
+            💡 <strong>Tip:</strong> Use "Always Allow" options to avoid
+            repeated permissions for trusted servers or tools.
+          </p>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/frontend/src/components/renderers/DefaultRenderer.tsx
+++ b/frontend/src/components/renderers/DefaultRenderer.tsx
@@ -10,6 +10,10 @@ export function DefaultRenderer({ toolCall }: DefaultRendererProps) {
   const { t } = useTranslation();
   const result = toolCall.result;
 
+  // Extract MCP server and tool names if available
+  const mcpServerName = toolCall.parameters?.serverName as string | undefined;
+  const mcpToolName = toolCall.parameters?.toolName as string | undefined;
+
   // Handle different result types
   const renderResult = () => {
     if (typeof result === "string") {
@@ -89,10 +93,17 @@ export function DefaultRenderer({ toolCall }: DefaultRendererProps) {
 
   return (
     <div className="space-y-4">
-      {/* Generic completion status card for unknown tools */}
+      {/* Generic completion status card - shows MCP tool names when available */}
       <div className="bg-green-50 dark:bg-green-950/20 border border-green-200 dark:border-green-800 rounded-md px-4 py-3">
         <div className="font-medium text-sm text-black dark:text-white mb-1 font-mono">
-          {formatToolName(toolCall.name)}
+          {mcpToolName
+            ? formatToolName(mcpToolName)
+            : formatToolName(toolCall.name)}
+          {mcpServerName && (
+            <span className="text-xs text-muted-foreground ml-2">
+              ({mcpServerName} MCP Server)
+            </span>
+          )}
         </div>
         <div className="flex items-center gap-2 text-sm text-green-700 dark:text-green-300">
           <Check className="size-3" />
@@ -108,7 +119,7 @@ export function DefaultRenderer({ toolCall }: DefaultRendererProps) {
           <div className="text-sm">
             <span className="font-medium">Tool Result</span>
             <span className="text-muted-foreground ml-2">
-              ({toolCall.name})
+              ({mcpToolName || toolCall.name})
             </span>
           </div>
         </div>

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -76,9 +76,35 @@ export interface ToolCallUpdateEvent {
   toolCallId: string | number;
   status: string;
   content?: ToolCallResult;
+  serverName?: string;
+  toolName?: string;
 }
 
 export type ErrorContent = ToolCallResult | string | null | undefined;
+
+// MCP Permission Types
+export interface McpPermissionOption {
+  optionId: string;
+  name: string;
+  kind: "allow_always" | "allow_once" | "reject_once" | "reject_always";
+}
+
+export interface McpToolCallInfo {
+  toolCallId: string;
+  status: string;
+  title: string;
+  content: unknown[];
+  locations: Location[];
+  kind: string;
+  serverName?: string;
+  toolName?: string;
+}
+
+export interface McpPermissionRequest {
+  sessionId: string;
+  options: McpPermissionOption[];
+  toolCall: McpToolCallInfo;
+}
 
 // Re-export MCP types
 export * from "./mcp";


### PR DESCRIPTION
- Extend SessionUpdate enum with serverName and toolName fields

- Add helper methods to retrieve server and tool names

- Update PermissionToolCall struct to include serverName and toolName

- Add MCP permission request types and related UI components

- Enhance ToolCallDisplay to render MCP calls and permission prompts

- Update DefaultRenderer to display MCP tool and server names

- Modify conversation event handling to propagate serverName and toolName

- Add comprehensive tests for MCP serialization and updates