### PR TITLE
feat(ui): improve command tool call display with compact approval UI

### DIFF
--- a/crates/backend/src/lib.rs
+++ b/crates/backend/src/lib.rs
@@ -459,28 +459,10 @@ impl<E: EventEmitter + 'static> GeminiBackend<E> {
         )
         .await;
 
-        // Create content items for the completed tool call
-        let content_items = vec![ToolCallContentItem::Content {
-            content: ContentBlock::Text {
-                text: "Tool call completed after user confirmation".to_string(),
-            },
-        }];
-
-        // Create ACP SessionUpdate instead of legacy ToolCallUpdate
-        let session_update = SessionUpdate::ToolCallUpdate {
-            tool_call_id: tool_call_id.clone(),
-            status: ToolCallStatus::Completed,
-            content: content_items,
-            server_name: None,
-            tool_name: None,
-        };
-
-        // Emit ACP session update event - use the conversation_id (frontend conversation ID), not ACP session ID
-        let emit_result = self.emitter.emit(
-            &format!("acp-session-update-{conversation_id}"),
-            session_update,
-        );
-        emit_result?;
+        // Do NOT mark the tool call as completed here.
+        // The CLI will emit subsequent session/update events with accurate status transitions.
+        // Returning Ok(()) ensures the frontend remains in "running" until a real "completed" arrives.
+        let _ = &tool_call_id; // keep parameter used for future extensions
         Ok(())
     }
 

--- a/frontend/src/components/common/ToolCallDisplay.tsx
+++ b/frontend/src/components/common/ToolCallDisplay.tsx
@@ -383,10 +383,10 @@ function ToolCallDisplayComponent({
                 onConfirm={onConfirm}
                 hasConfirmationRequest={hasConfirmationRequest}
               />
-            ) : (enhancedToolCall.confirmationRequest?.confirmation?.type ===
-              "command" || 
+            ) : enhancedToolCall.confirmationRequest?.confirmation?.type ===
+                "command" ||
               enhancedToolCall.name === "run_shell_command" ||
-              enhancedToolCall.name === "execute_command") ? (
+              enhancedToolCall.name === "execute_command" ? (
               // Command-specific confirmation UI
               <div className="mt-4">
                 <div className="flex items-center gap-2 text-sm px-2 py-1 hover:bg-muted/50 rounded-lg transition-colors">
@@ -394,7 +394,8 @@ function ToolCallDisplayComponent({
                   <span>
                     {t("toolCalls.pendingApproval")}{" "}
                     <span className="text-muted-foreground font-mono">
-                      {enhancedToolCall.label?.match(/^(\S+)/)?.[1] || "command"}
+                      {enhancedToolCall.label?.match(/^(\S+)/)?.[1] ||
+                        "command"}
                     </span>
                   </span>
 

--- a/frontend/src/components/renderers/CommandRenderer.tsx
+++ b/frontend/src/components/renderers/CommandRenderer.tsx
@@ -26,42 +26,11 @@ export function CommandRenderer({ toolCall }: CommandRendererProps) {
   const isStringResult = typeof toolCall.result === "string";
   const result: CommandResult = isStringResult
     ? { output: toolCall.result as string }
-    : ((toolCall.result as CommandResult) || {});
+    : (toolCall.result as CommandResult) || {};
 
   // Parse a compact, human-readable description
   const parsedInput = ToolInputParser.parseToolInput(toolCall);
 
-  // Extract command from input (for details section)
-  const getCommand = (): string => {
-    // First check if ToolInputParser has already extracted the command
-    if (parsedInput.allParams.command) {
-      return parsedInput.allParams.command;
-    }
-    
-    try {
-      if (toolCall.inputJsonRpc) {
-        const input = JSON.parse(toolCall.inputJsonRpc);
-        // First try to get from params.command/cmd
-        if (input.params?.command || input.params?.cmd) {
-          return input.params.command || input.params.cmd;
-        }
-        // For session/request_permission messages, extract from toolCall.title
-        if (input.method === "session/request_permission" && input.params?.toolCall?.title) {
-          const title = input.params.toolCall.title;
-          // Extract command from title like "dir (List files and directories in the current directory.)"
-          const commandMatch = title.match(/^(\S+)/);
-          if (commandMatch) {
-            return commandMatch[1];
-          }
-        }
-      }
-    } catch {
-      // Ignore parse errors
-    }
-    return result.command || "unknown command";
-  };
-
-  const command = getCommand();
   const exitCode = result.exit_code ?? 0;
   const isSuccess = exitCode === 0;
 
@@ -69,21 +38,6 @@ export function CommandRenderer({ toolCall }: CommandRendererProps) {
   const stdout = result.stdout || result.output || "";
   const stderr = result.stderr || result.error || "";
   const hasOutput = !!(stdout || stderr);
-
-  // Compact summary line (used in expanded details header)
-  const getSummary = (): string => {
-    if (!isSuccess) {
-      const err = stderr || result.message || "Command failed";
-      const first = err.split(/\r?\n/)[0];
-      return first.length > 120 ? first.slice(0, 117) + "..." : first;
-    }
-    if (stdout) {
-      const first = stdout.split(/\r?\n/)[0] || "Command completed";
-      return first.length > 120 ? first.slice(0, 117) + "..." : first;
-    }
-    if (result.message) return result.message;
-    return t("toolCalls.completed");
-  };
 
   // Status color for icon
   const iconColor =
@@ -107,7 +61,9 @@ export function CommandRenderer({ toolCall }: CommandRendererProps) {
           parsedInput.formattedDescription.parts.map((part, index) => (
             <span
               key={index}
-              className={part.isHighlighted ? "text-muted-foreground font-mono" : ""}
+              className={
+                part.isHighlighted ? "text-muted-foreground font-mono" : ""
+              }
             >
               {part.text}
             </span>
@@ -146,7 +102,9 @@ export function CommandRenderer({ toolCall }: CommandRendererProps) {
             <div className="space-y-1">
               <div className="flex items-center gap-2">
                 <AlertTriangle className="h-4 w-4 text-amber-500" />
-                <div className="text-sm font-medium text-foreground">Stderr</div>
+                <div className="text-sm font-medium text-foreground">
+                  Stderr
+                </div>
               </div>
               <pre className="bg-red-50 dark:bg-red-950/20 p-3 rounded-md text-sm overflow-x-auto border border-red-200 dark:border-red-800">
                 <code className="text-red-800 dark:text-red-200">{stderr}</code>

--- a/frontend/src/components/renderers/CommandRenderer.tsx
+++ b/frontend/src/components/renderers/CommandRenderer.tsx
@@ -1,6 +1,8 @@
-import { Terminal, CheckCircle, XCircle, AlertTriangle } from "lucide-react";
+import { useState } from "react";
+import { Terminal, ChevronRight, AlertTriangle } from "lucide-react";
 import { useTranslation } from "react-i18next";
 import { type ToolCall } from "../../utils/toolCallParser";
+import { ToolInputParser } from "../../utils/toolInputParser";
 
 interface CommandResult {
   stdout?: string;
@@ -18,17 +20,43 @@ interface CommandRendererProps {
 
 export function CommandRenderer({ toolCall }: CommandRendererProps) {
   const { t } = useTranslation();
-  const result = toolCall.result as CommandResult;
+  const [isExpanded, setIsExpanded] = useState(false);
 
-  // Extract command from input
+  // Normalize result: accept string or structured object
+  const isStringResult = typeof toolCall.result === "string";
+  const result: CommandResult = isStringResult
+    ? { output: toolCall.result as string }
+    : ((toolCall.result as CommandResult) || {});
+
+  // Parse a compact, human-readable description
+  const parsedInput = ToolInputParser.parseToolInput(toolCall);
+
+  // Extract command from input (for details section)
   const getCommand = (): string => {
+    // First check if ToolInputParser has already extracted the command
+    if (parsedInput.allParams.command) {
+      return parsedInput.allParams.command;
+    }
+    
     try {
       if (toolCall.inputJsonRpc) {
         const input = JSON.parse(toolCall.inputJsonRpc);
-        return input.params?.command || input.params?.cmd || "unknown command";
+        // First try to get from params.command/cmd
+        if (input.params?.command || input.params?.cmd) {
+          return input.params.command || input.params.cmd;
+        }
+        // For session/request_permission messages, extract from toolCall.title
+        if (input.method === "session/request_permission" && input.params?.toolCall?.title) {
+          const title = input.params.toolCall.title;
+          // Extract command from title like "dir (List files and directories in the current directory.)"
+          const commandMatch = title.match(/^(\S+)/);
+          if (commandMatch) {
+            return commandMatch[1];
+          }
+        }
       }
     } catch {
-      // Intentionally ignore parse errors
+      // Ignore parse errors
     }
     return result.command || "unknown command";
   };
@@ -37,108 +65,101 @@ export function CommandRenderer({ toolCall }: CommandRendererProps) {
   const exitCode = result.exit_code ?? 0;
   const isSuccess = exitCode === 0;
 
-  // Get output content
+  // Output content
   const stdout = result.stdout || result.output || "";
   const stderr = result.stderr || result.error || "";
-  const hasOutput = stdout || stderr;
+  const hasOutput = !!(stdout || stderr);
 
-  // Determine status and icon
-  const getStatusInfo = () => {
-    if (isSuccess && hasOutput) {
-      return {
-        icon: CheckCircle,
-        color: "text-green-500",
-        bgColor: "bg-green-50 dark:bg-green-950/20",
-        borderColor: "border-green-200 dark:border-green-800",
-        label: t("toolCalls.success"),
-      };
-    } else if (isSuccess && !hasOutput) {
-      return {
-        icon: CheckCircle,
-        color: "text-green-500",
-        bgColor: "bg-green-50 dark:bg-green-950/20",
-        borderColor: "border-green-200 dark:border-green-800",
-        label: t("toolCalls.completed"),
-      };
-    } else {
-      return {
-        icon: XCircle,
-        color: "text-red-500",
-        bgColor: "bg-red-50 dark:bg-red-950/20",
-        borderColor: "border-red-200 dark:border-red-800",
-        label: t("toolCalls.failed"),
-      };
+  // Compact summary line (used in expanded details header)
+  const getSummary = (): string => {
+    if (!isSuccess) {
+      const err = stderr || result.message || "Command failed";
+      const first = err.split(/\r?\n/)[0];
+      return first.length > 120 ? first.slice(0, 117) + "..." : first;
     }
+    if (stdout) {
+      const first = stdout.split(/\r?\n/)[0] || "Command completed";
+      return first.length > 120 ? first.slice(0, 117) + "..." : first;
+    }
+    if (result.message) return result.message;
+    return t("toolCalls.completed");
   };
 
-  const status = getStatusInfo();
-  const StatusIcon = status.icon;
+  // Status color for icon
+  const iconColor =
+    toolCall.status === "failed"
+      ? "text-red-500"
+      : toolCall.status === "completed"
+        ? isSuccess
+          ? "text-blue-500"
+          : "text-red-500"
+        : "text-blue-500";
 
   return (
-    <div className="mt-4 space-y-4">
-      {/* Header */}
-      <div className="flex items-center gap-2">
-        <Terminal className="h-4 w-4 text-muted-foreground" />
-        <div className="text-sm">
-          <span className="font-medium">Command Execution</span>
-          <div className="text-xs text-muted-foreground font-mono mt-1">
-            {command}
-          </div>
-        </div>
-      </div>
-
-      {/* Status */}
+    <div className="mt-4">
+      {/* Compact one-line header, consistent with grep/glob/list/web */}
       <div
-        className={`flex items-center gap-2 px-3 py-2 rounded-md ${status.bgColor} ${status.borderColor} border`}
+        className="flex items-center gap-2 text-sm px-2 py-1 cursor-pointer hover:bg-muted/50 rounded-lg transition-colors"
+        onClick={() => setIsExpanded((v) => !v)}
       >
-        <StatusIcon className={`h-4 w-4 ${status.color}`} />
-        <span className="text-sm font-medium">{status.label}</span>
-        {exitCode !== undefined && (
-          <span className="text-xs text-muted-foreground">
-            (exit code: {exitCode})
-          </span>
+        <Terminal className={`h-4 w-4 ${iconColor}`} />
+        {parsedInput.formattedDescription ? (
+          parsedInput.formattedDescription.parts.map((part, index) => (
+            <span
+              key={index}
+              className={part.isHighlighted ? "text-muted-foreground font-mono" : ""}
+            >
+              {part.text}
+            </span>
+          ))
+        ) : (
+          <span>{parsedInput.description}</span>
         )}
+        <ChevronRight
+          className={`h-4 w-4 text-muted-foreground transition-transform ${
+            isExpanded ? "rotate-90" : ""
+          }`}
+        />
       </div>
 
-      {/* Output sections */}
-      {stdout && (
-        <div className="space-y-2">
-          <div className="flex items-center gap-2">
-            <div className="text-sm font-medium text-foreground">
-              Standard Output
-            </div>
+      {/* Expanded details */}
+      {isExpanded && (
+        <div className="ml-8 mt-2 space-y-3">
+          {/* Status line */}
+          <div className="text-xs text-muted-foreground">
+            {isSuccess ? t("toolCalls.completed") : t("toolCalls.failed")}{" "}
+            {Number.isFinite(exitCode) ? `(exit code: ${exitCode})` : ""}
           </div>
-          <pre className="bg-muted p-3 rounded-md text-sm overflow-x-auto border">
-            <code className="text-foreground">{stdout}</code>
-          </pre>
-        </div>
-      )}
 
-      {stderr && (
-        <div className="space-y-2">
-          <div className="flex items-center gap-2">
-            <AlertTriangle className="h-4 w-4 text-amber-500" />
-            <div className="text-sm font-medium text-foreground">
-              Standard Error
+          {/* Stdout */}
+          {stdout && (
+            <div className="space-y-1">
+              <div className="text-sm font-medium text-foreground">Stdout</div>
+              <pre className="bg-muted p-3 rounded-md text-sm overflow-x-auto border">
+                <code className="text-foreground">{stdout}</code>
+              </pre>
             </div>
-          </div>
-          <pre className="bg-red-50 dark:bg-red-950/20 p-3 rounded-md text-sm overflow-x-auto border border-red-200 dark:border-red-800">
-            <code className="text-red-800 dark:text-red-200">{stderr}</code>
-          </pre>
-        </div>
-      )}
+          )}
 
-      {/* Message fallback */}
-      {!hasOutput && result.message && (
-        <div className="text-sm text-muted-foreground p-3 bg-gray-50 dark:bg-gray-800 rounded-md">
-          {result.message}
-        </div>
-      )}
+          {/* Stderr */}
+          {stderr && (
+            <div className="space-y-1">
+              <div className="flex items-center gap-2">
+                <AlertTriangle className="h-4 w-4 text-amber-500" />
+                <div className="text-sm font-medium text-foreground">Stderr</div>
+              </div>
+              <pre className="bg-red-50 dark:bg-red-950/20 p-3 rounded-md text-sm overflow-x-auto border border-red-200 dark:border-red-800">
+                <code className="text-red-800 dark:text-red-200">{stderr}</code>
+              </pre>
+            </div>
+          )}
 
-      {/* No output indicator */}
-      {!hasOutput && !result.message && isSuccess && (
-        <div className="text-sm text-muted-foreground p-3 bg-gray-50 dark:bg-gray-800 rounded-md text-center">
-          Command completed with no output
+          {/* No output */}
+          {!hasOutput && isSuccess && (
+            <div className="text-sm text-muted-foreground">
+              {t("toolCalls.completed")}
+            </div>
+          )}
         </div>
       )}
     </div>

--- a/frontend/src/utils/toolInputParser.ts
+++ b/frontend/src/utils/toolInputParser.ts
@@ -65,11 +65,13 @@ export class ToolInputParser {
       if (toolCall.inputJsonRpc) {
         const input = JSON.parse(toolCall.inputJsonRpc);
         allParams = input.params || {};
-        
+
         // For session/request_permission messages, extract command from toolCall.title
-        if (input.method === "session/request_permission" && 
-            input.params?.toolCall?.title && 
-            input.params.toolCall.kind === "execute") {
+        if (
+          input.method === "session/request_permission" &&
+          input.params?.toolCall?.title &&
+          input.params.toolCall.kind === "execute"
+        ) {
           const title = input.params.toolCall.title;
           // Extract command from title like "dir (List files and directories in the current directory.)"
           const commandMatch = title.match(/^(\S+)/);
@@ -232,7 +234,7 @@ export class ToolInputParser {
       case "run_shell_command":
       case "execute_command": {
         let command = params.command || params.cmd;
-        
+
         // If no command found and we have a label, try to extract from it
         if (!command && label) {
           // Extract command from label like "dir (List files and directories in the current directory.)"
@@ -241,15 +243,15 @@ export class ToolInputParser {
             command = commandMatch[1];
           }
         }
-        
+
         command = command || "unknown command";
-        
+
         // Truncate long commands
         const shortCommand =
           typeof command === "string" && command.length > 50
             ? command.substring(0, 50) + "..."
             : command;
-        
+
         return {
           description: `Executing ${shortCommand}`,
           formattedDescription: {

--- a/frontend/src/utils/toolInputParser.ts
+++ b/frontend/src/utils/toolInputParser.ts
@@ -65,6 +65,18 @@ export class ToolInputParser {
       if (toolCall.inputJsonRpc) {
         const input = JSON.parse(toolCall.inputJsonRpc);
         allParams = input.params || {};
+        
+        // For session/request_permission messages, extract command from toolCall.title
+        if (input.method === "session/request_permission" && 
+            input.params?.toolCall?.title && 
+            input.params.toolCall.kind === "execute") {
+          const title = input.params.toolCall.title;
+          // Extract command from title like "dir (List files and directories in the current directory.)"
+          const commandMatch = title.match(/^(\S+)/);
+          if (commandMatch) {
+            allParams.command = commandMatch[1];
+          }
+        }
       }
     } catch {
       // Fallback to toolCall.parameters
@@ -219,13 +231,34 @@ export class ToolInputParser {
 
       case "run_shell_command":
       case "execute_command": {
-        const command = params.command || params.cmd || "unknown command";
+        let command = params.command || params.cmd;
+        
+        // If no command found and we have a label, try to extract from it
+        if (!command && label) {
+          // Extract command from label like "dir (List files and directories in the current directory.)"
+          const commandMatch = label.match(/^(\S+)/);
+          if (commandMatch) {
+            command = commandMatch[1];
+          }
+        }
+        
+        command = command || "unknown command";
+        
         // Truncate long commands
         const shortCommand =
           typeof command === "string" && command.length > 50
             ? command.substring(0, 50) + "..."
             : command;
-        return `Executing: ${shortCommand}`;
+        
+        return {
+          description: `Executing ${shortCommand}`,
+          formattedDescription: {
+            parts: [
+              { text: "Executing ", isHighlighted: false },
+              { text: shortCommand, isHighlighted: true },
+            ],
+          },
+        };
       }
 
       case "delete_file":


### PR DESCRIPTION
- Add command-specific confirmation UI with terminal icon and compact approval buttons for shell commands

- Refactor CommandRenderer to use collapsible design consistent with other tool renderers, showing compact summary by default

- Remove premature tool call completion marking in backend to allow proper status transitions from CLI

- Enhance tool input parser to extract commands from session permission requests and improve command display formatting

Closes #83