### PR TITLE
feat(filesystem): add file writing capability to directory tree with

### DIFF
--- a/crates/backend/src/lib.rs
+++ b/crates/backend/src/lib.rs
@@ -685,6 +685,11 @@ impl<E: EventEmitter + 'static> GeminiBackend<E> {
     pub async fn read_file_content(&self, path: String) -> Result<FileContent> {
         filesystem::read_file_content(path).await
     }
+
+    /// Write file content with safety checks
+    pub async fn write_file_content(&self, path: String, content: String) -> Result<FileContent> {
+        filesystem::write_file_content(path, content).await
+    }
 }
 
 #[cfg(test)]

--- a/crates/server/src/main.rs
+++ b/crates/server/src/main.rs
@@ -300,6 +300,13 @@ struct ReadFileContentRequest {
     path: String,
 }
 
+#[derive(Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct WriteFileContentRequest {
+    path: String,
+    content: String,
+}
+
 #[derive(Debug)]
 pub struct AnyhowResponder(pub AnyhowError);
 
@@ -706,6 +713,20 @@ async fn read_file_content(
     ))
 }
 
+#[post("/write-file-content", data = "<request>")]
+async fn write_file_content(
+    request: Json<WriteFileContentRequest>,
+    state: &State<AppState>,
+) -> AppResult<Json<FileContent>> {
+    let backend = state.backend.lock().await;
+    Ok(Json(
+        backend
+            .write_file_content(request.path.clone(), request.content.clone())
+            .await
+            .context("Failed to write file content")?,
+    ))
+}
+
 // =====================================
 // WebSocket Route Handler
 // =====================================
@@ -800,6 +821,7 @@ fn rocket() -> _ {
             get_enriched_project_http,
             get_project_discussions,
             read_file_content,
+            write_file_content,
         ],
     )
 }

--- a/crates/tauri-app/src/commands/mod.rs
+++ b/crates/tauri-app/src/commands/mod.rs
@@ -503,3 +503,16 @@ pub async fn read_file_content(
         .await
         .map_err(|e| format!("{e:#}"))
 }
+
+#[tauri::command]
+pub async fn write_file_content(
+    path: String,
+    content: String,
+    state: State<'_, AppState>,
+) -> Result<FileContent, String> {
+    state
+        .backend
+        .write_file_content(path, content)
+        .await
+        .map_err(|e| format!("{e:#}"))
+}

--- a/crates/tauri-app/src/lib.rs
+++ b/crates/tauri-app/src/lib.rs
@@ -81,6 +81,7 @@ pub fn run() {
             commands::read_settings_file,
             commands::write_settings_file,
             commands::read_file_content,
+            commands::write_file_content,
             menu::init_menu,
             menu::update_menu_labels
         ]);

--- a/frontend/src/components/common/CodeMirrorViewer.tsx
+++ b/frontend/src/components/common/CodeMirrorViewer.tsx
@@ -16,6 +16,7 @@ interface CodeMirrorViewerProps {
   code: string;
   language: string;
   readOnly?: boolean;
+  onChange?: (value: string) => void;
 }
 
 // Language extension mapping
@@ -56,6 +57,7 @@ export function CodeMirrorViewer({
   code,
   language,
   readOnly = true,
+  onChange,
 }: CodeMirrorViewerProps) {
   const { resolvedTheme } = useTheme();
   const [mounted, setMounted] = useState(false);
@@ -100,6 +102,7 @@ export function CodeMirrorViewer({
         theme={theme}
         extensions={extensions}
         readOnly={readOnly}
+        onChange={onChange}
         basicSetup={{
           lineNumbers: true,
           foldGutter: true,

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -107,6 +107,16 @@ export interface API {
     is_binary: boolean;
     error: string | null;
   }>;
+  write_file_content(params: { path: string; content: string }): Promise<{
+    path: string;
+    content: string | null;
+    size: number;
+    modified: number | null;
+    encoding: string;
+    is_text: boolean;
+    is_binary: boolean;
+    error: string | null;
+  }>;
 }
 
 export type APICommand = keyof API;

--- a/frontend/src/lib/webApi.ts
+++ b/frontend/src/lib/webApi.ts
@@ -180,6 +180,11 @@ export const webApi: API = {
     const response = await apiClient.post("/read-file-content", params);
     return response.data;
   },
+
+  async write_file_content(params) {
+    const response = await apiClient.post("/write-file-content", params);
+    return response.data;
+  },
 };
 
 export interface RecentChat {


### PR DESCRIPTION
- Add write_file_content function to filesystem module with parent directory validation

- Implement write_file_content API endpoint in server with proper error handling

- Add write_file_content command to Tauri app for desktop file operations

- Enhance FileContentViewer with edit mode, save/cancel functionality, and user feedback

- Update CodeMirrorViewer to support onChange callback for editing capabilities

- Extend API interfaces to include write_file_content method across web and Tauri clients