### PR TITLE
feat(filesystem): add force text option for binary file viewing

### DIFF
--- a/crates/backend/src/filesystem/mod.rs
+++ b/crates/backend/src/filesystem/mod.rs
@@ -636,7 +636,7 @@ pub async fn read_file_content_with_options(path: String, force_text: bool) -> R
     // Check if content is valid UTF-8
     let is_valid_utf8 = std::str::from_utf8(&buffer).is_ok();
     let is_binary = !is_valid_utf8;
-    
+
     // If force_text is true, always try to show content even for binary files
     let show_as_text = is_valid_utf8 || force_text;
 

--- a/crates/backend/src/lib.rs
+++ b/crates/backend/src/lib.rs
@@ -687,7 +687,11 @@ impl<E: EventEmitter + 'static> GeminiBackend<E> {
     }
 
     /// Read file content with options to force display as text
-    pub async fn read_file_content_with_options(&self, path: String, force_text: bool) -> Result<FileContent> {
+    pub async fn read_file_content_with_options(
+        &self,
+        path: String,
+        force_text: bool,
+    ) -> Result<FileContent> {
         filesystem::read_file_content_with_options(path, force_text).await
     }
 

--- a/crates/backend/src/lib.rs
+++ b/crates/backend/src/lib.rs
@@ -686,6 +686,11 @@ impl<E: EventEmitter + 'static> GeminiBackend<E> {
         filesystem::read_file_content(path).await
     }
 
+    /// Read file content with options to force display as text
+    pub async fn read_file_content_with_options(&self, path: String, force_text: bool) -> Result<FileContent> {
+        filesystem::read_file_content_with_options(path, force_text).await
+    }
+
     /// Write file content with safety checks
     pub async fn write_file_content(&self, path: String, content: String) -> Result<FileContent> {
         filesystem::write_file_content(path, content).await

--- a/crates/server/src/main.rs
+++ b/crates/server/src/main.rs
@@ -302,6 +302,13 @@ struct ReadFileContentRequest {
 
 #[derive(Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
+struct ReadFileContentWithOptionsRequest {
+    path: String,
+    force_text: bool,
+}
+
+#[derive(Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 struct WriteFileContentRequest {
     path: String,
     content: String,
@@ -713,6 +720,20 @@ async fn read_file_content(
     ))
 }
 
+#[post("/read-file-content-with-options", data = "<request>")]
+async fn read_file_content_with_options(
+    request: Json<ReadFileContentWithOptionsRequest>,
+    state: &State<AppState>,
+) -> AppResult<Json<FileContent>> {
+    let backend = state.backend.lock().await;
+    Ok(Json(
+        backend
+            .read_file_content_with_options(request.path.clone(), request.force_text)
+            .await
+            .context("Failed to read file content with options")?,
+    ))
+}
+
 #[post("/write-file-content", data = "<request>")]
 async fn write_file_content(
     request: Json<WriteFileContentRequest>,
@@ -821,6 +842,7 @@ fn rocket() -> _ {
             get_enriched_project_http,
             get_project_discussions,
             read_file_content,
+            read_file_content_with_options,
             write_file_content,
         ],
     )

--- a/crates/tauri-app/src/commands/mod.rs
+++ b/crates/tauri-app/src/commands/mod.rs
@@ -505,6 +505,19 @@ pub async fn read_file_content(
 }
 
 #[tauri::command]
+pub async fn read_file_content_with_options(
+    path: String,
+    force_text: bool,
+    state: State<'_, AppState>,
+) -> Result<FileContent, String> {
+    state
+        .backend
+        .read_file_content_with_options(path, force_text)
+        .await
+        .map_err(|e| format!("{e:#}"))
+}
+
+#[tauri::command]
 pub async fn write_file_content(
     path: String,
     content: String,

--- a/crates/tauri-app/src/lib.rs
+++ b/crates/tauri-app/src/lib.rs
@@ -81,6 +81,7 @@ pub fn run() {
             commands::read_settings_file,
             commands::write_settings_file,
             commands::read_file_content,
+            commands::read_file_content_with_options,
             commands::write_file_content,
             menu::init_menu,
             menu::update_menu_labels

--- a/frontend/src/components/common/FileContentViewer.tsx
+++ b/frontend/src/components/common/FileContentViewer.tsx
@@ -53,9 +53,9 @@ export function FileContentViewer({
       setError(null);
 
       try {
-        const content = await api.read_file_content_with_options({ 
+        const content = await api.read_file_content_with_options({
           path: filePath,
-          forceText: forceViewAsText
+          forceText: forceViewAsText,
         });
         setFileContent(content);
         setEditedContent(content.content || "");
@@ -77,7 +77,10 @@ export function FileContentViewer({
   }, [filePath, forceViewAsText]);
 
   const handleEdit = () => {
-    if ((fileContent?.is_text || (fileContent?.is_binary && forceViewAsText)) && fileContent.content !== null) {
+    if (
+      (fileContent?.is_text || (fileContent?.is_binary && forceViewAsText)) &&
+      fileContent.content !== null
+    ) {
       setIsEditing(true);
       setEditedContent(fileContent.content);
     }
@@ -248,10 +251,20 @@ export function FileContentViewer({
                 <div className="flex items-center gap-2 text-xs text-muted-foreground">
                   <span>{fileContent.encoding}</span>
                   <Badge
-                    variant={fileContent.is_binary && forceViewAsText ? "destructive" : fileContent.is_text ? "default" : "secondary"}
+                    variant={
+                      fileContent.is_binary && forceViewAsText
+                        ? "destructive"
+                        : fileContent.is_text
+                          ? "default"
+                          : "secondary"
+                    }
                     className="text-xs px-1.5 py-0.5"
                   >
-                    {fileContent.is_binary && forceViewAsText ? "Binary (forced as text)" : fileContent.is_text ? "Text" : "Binary"}
+                    {fileContent.is_binary && forceViewAsText
+                      ? "Binary (forced as text)"
+                      : fileContent.is_text
+                        ? "Text"
+                        : "Binary"}
                   </Badge>
                   {fileContent.is_binary && forceViewAsText && (
                     <Button
@@ -266,64 +279,66 @@ export function FileContentViewer({
                 </div>
 
                 <div className="flex items-center gap-1">
-                  {(fileContent.is_text || (fileContent.is_binary && forceViewAsText)) && fileContent.content !== null && (
-                    <>
-                      {!isEditing ? (
-                        <>
-                          <Button
-                            variant="ghost"
-                            size="sm"
-                            onClick={handleEdit}
-                            className="text-xs h-7 px-2"
-                          >
-                            <Edit className="h-3.5 w-3.5 mr-1" />
-                            Edit
-                          </Button>
-                          <Button
-                            variant="ghost"
-                            size="sm"
-                            onClick={handleCopy}
-                            className="text-xs h-7 px-2"
-                          >
-                            <Copy className="h-3.5 w-3.5 mr-1" />
-                            {copied ? t("common.copied") : t("common.copy")}
-                          </Button>
-                          <Button
-                            variant="ghost"
-                            size="sm"
-                            onClick={handleDownload}
-                            className="text-xs h-7 px-2"
-                          >
-                            <Download className="h-3.5 w-3.5 mr-1" />
-                            Download
-                          </Button>
-                        </>
-                      ) : (
-                        <>
-                          <Button
-                            variant="default"
-                            size="sm"
-                            onClick={handleSave}
-                            disabled={saving}
-                            className="text-xs h-7 px-2"
-                          >
-                            <Save className="h-3.5 w-3.5 mr-1" />
-                            {saving ? "Saving..." : "Save"}
-                          </Button>
-                          <Button
-                            variant="ghost"
-                            size="sm"
-                            onClick={handleCancel}
-                            disabled={saving}
-                            className="text-xs h-7 px-2"
-                          >
-                            <X className="h-3.5 w-3.5 mr-1" />
-                            Cancel
-                          </Button>
-                        </>
-                      )}
-                    </>
-                  )}
+                  {(fileContent.is_text ||
+                    (fileContent.is_binary && forceViewAsText)) &&
+                    fileContent.content !== null && (
+                      <>
+                        {!isEditing ? (
+                          <>
+                            <Button
+                              variant="ghost"
+                              size="sm"
+                              onClick={handleEdit}
+                              className="text-xs h-7 px-2"
+                            >
+                              <Edit className="h-3.5 w-3.5 mr-1" />
+                              Edit
+                            </Button>
+                            <Button
+                              variant="ghost"
+                              size="sm"
+                              onClick={handleCopy}
+                              className="text-xs h-7 px-2"
+                            >
+                              <Copy className="h-3.5 w-3.5 mr-1" />
+                              {copied ? t("common.copied") : t("common.copy")}
+                            </Button>
+                            <Button
+                              variant="ghost"
+                              size="sm"
+                              onClick={handleDownload}
+                              className="text-xs h-7 px-2"
+                            >
+                              <Download className="h-3.5 w-3.5 mr-1" />
+                              Download
+                            </Button>
+                          </>
+                        ) : (
+                          <>
+                            <Button
+                              variant="default"
+                              size="sm"
+                              onClick={handleSave}
+                              disabled={saving}
+                              className="text-xs h-7 px-2"
+                            >
+                              <Save className="h-3.5 w-3.5 mr-1" />
+                              {saving ? "Saving..." : "Save"}
+                            </Button>
+                            <Button
+                              variant="ghost"
+                              size="sm"
+                              onClick={handleCancel}
+                              disabled={saving}
+                              className="text-xs h-7 px-2"
+                            >
+                              <X className="h-3.5 w-3.5 mr-1" />
+                              Cancel
+                            </Button>
+                          </>
+                        )}
+                      </>
+                    )}
                 </div>
               </div>
 

--- a/frontend/src/components/common/FileContentViewer.tsx
+++ b/frontend/src/components/common/FileContentViewer.tsx
@@ -36,6 +36,7 @@ export function FileContentViewer({
   const [isEditing, setIsEditing] = useState(false);
   const [editedContent, setEditedContent] = useState<string>("");
   const [saving, setSaving] = useState(false);
+  const [forceViewAsText, setForceViewAsText] = useState(false);
 
   const isOpen = filePath !== null;
 
@@ -43,6 +44,7 @@ export function FileContentViewer({
     if (!filePath) {
       setFileContent(null);
       setError(null);
+      setForceViewAsText(false);
       return;
     }
 
@@ -51,7 +53,10 @@ export function FileContentViewer({
       setError(null);
 
       try {
-        const content = await api.read_file_content({ path: filePath });
+        const content = await api.read_file_content_with_options({ 
+          path: filePath,
+          forceText: forceViewAsText
+        });
         setFileContent(content);
         setEditedContent(content.content || "");
         setIsEditing(false);
@@ -69,10 +74,10 @@ export function FileContentViewer({
     };
 
     loadFileContent();
-  }, [filePath]);
+  }, [filePath, forceViewAsText]);
 
   const handleEdit = () => {
-    if (fileContent?.is_text && fileContent.content !== null) {
+    if ((fileContent?.is_text || (fileContent?.is_binary && forceViewAsText)) && fileContent.content !== null) {
       setIsEditing(true);
       setEditedContent(fileContent.content);
     }
@@ -243,15 +248,25 @@ export function FileContentViewer({
                 <div className="flex items-center gap-2 text-xs text-muted-foreground">
                   <span>{fileContent.encoding}</span>
                   <Badge
-                    variant={fileContent.is_text ? "default" : "secondary"}
+                    variant={fileContent.is_binary && forceViewAsText ? "destructive" : fileContent.is_text ? "default" : "secondary"}
                     className="text-xs px-1.5 py-0.5"
                   >
-                    {fileContent.is_text ? "Text" : "Binary"}
+                    {fileContent.is_binary && forceViewAsText ? "Binary (forced as text)" : fileContent.is_text ? "Text" : "Binary"}
                   </Badge>
+                  {fileContent.is_binary && forceViewAsText && (
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      onClick={() => setForceViewAsText(false)}
+                      className="text-xs h-6 px-2 text-muted-foreground hover:text-foreground"
+                    >
+                      Back to binary view
+                    </Button>
+                  )}
                 </div>
 
                 <div className="flex items-center gap-1">
-                  {fileContent.is_text && fileContent.content !== null && (
+                  {(fileContent.is_text || (fileContent.is_binary && forceViewAsText)) && fileContent.content !== null && (
                     <>
                       {!isEditing ? (
                         <>
@@ -314,15 +329,22 @@ export function FileContentViewer({
 
               {/* File content */}
               <div className="flex-1 overflow-hidden">
-                {fileContent.is_binary ? (
+                {fileContent.is_binary && !forceViewAsText ? (
                   <div className="text-center py-8 text-muted-foreground">
                     <FileText className="h-12 w-12 mx-auto mb-4 opacity-50" />
                     <p>
                       This is a binary file and cannot be displayed as text.
                     </p>
-                    <p className="text-sm mt-2">
+                    <p className="text-sm mt-2 mb-4">
                       Size: {formatFileSize(fileContent.size)}
                     </p>
+                    <Button
+                      variant="outline"
+                      onClick={() => setForceViewAsText(true)}
+                      className="text-sm"
+                    >
+                      View anyway
+                    </Button>
                   </div>
                 ) : fileContent.content !== null ? (
                   <div className="h-full overflow-auto">

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -107,6 +107,16 @@ export interface API {
     is_binary: boolean;
     error: string | null;
   }>;
+  read_file_content_with_options(params: { path: string; forceText: boolean }): Promise<{
+    path: string;
+    content: string | null;
+    size: number;
+    modified: number | null;
+    encoding: string;
+    is_text: boolean;
+    is_binary: boolean;
+    error: string | null;
+  }>;
   write_file_content(params: { path: string; content: string }): Promise<{
     path: string;
     content: string | null;

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -107,7 +107,10 @@ export interface API {
     is_binary: boolean;
     error: string | null;
   }>;
-  read_file_content_with_options(params: { path: string; forceText: boolean }): Promise<{
+  read_file_content_with_options(params: {
+    path: string;
+    forceText: boolean;
+  }): Promise<{
     path: string;
     content: string | null;
     size: number;

--- a/frontend/src/lib/webApi.ts
+++ b/frontend/src/lib/webApi.ts
@@ -182,7 +182,10 @@ export const webApi: API = {
   },
 
   async read_file_content_with_options(params) {
-    const response = await apiClient.post("/read-file-content-with-options", params);
+    const response = await apiClient.post(
+      "/read-file-content-with-options",
+      params
+    );
     return response.data;
   },
 

--- a/frontend/src/lib/webApi.ts
+++ b/frontend/src/lib/webApi.ts
@@ -181,6 +181,11 @@ export const webApi: API = {
     return response.data;
   },
 
+  async read_file_content_with_options(params) {
+    const response = await apiClient.post("/read-file-content-with-options", params);
+    return response.data;
+  },
+
   async write_file_content(params) {
     const response = await apiClient.post("/write-file-content", params);
     return response.data;


### PR DESCRIPTION
- Add `read_file_content_with_options` function with `force_text` parameter to allow viewing binary files as text

- Implement new API endpoint `/read-file-content-with-options` in server and Tauri commands

- Update FileContentViewer UI to show "View anyway" button for binary files and handle forced text display

- Maintain backward compatibility by keeping original `read_file_content` function as wrapper