### PR TITLE
fix(session): remove timeout from JSON-RPC response reading

### DIFF
--- a/crates/backend/src/session/mod.rs
+++ b/crates/backend/src/session/mod.rs
@@ -230,15 +230,8 @@ async fn send_jsonrpc_request<E: EventEmitter>(
     let mut line = String::new();
     let trimmed_line = loop {
         line.clear();
-        select! {
-            result = reader.read_line(&mut line) => {
-                if let Err(e) = result {
-                    anyhow::bail!("Failed to read response: {e}");
-                }
-            }
-            _ = sleep(Duration::from_secs(10)) => {
-                return Ok(None);
-            }
+        if let Err(e) = reader.read_line(&mut line).await {
+            anyhow::bail!("Failed to read response: {e}");
         }
 
         let trimmed = line.trim();

--- a/crates/backend/src/session/mod.rs
+++ b/crates/backend/src/session/mod.rs
@@ -4,7 +4,6 @@ use std::process::Stdio;
 use std::sync::{Arc, Mutex};
 use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader as AsyncBufReader};
 use tokio::process::{Child, ChildStdin, ChildStdout, Command};
-use tokio::select;
 use tokio::sync::mpsc;
 use tokio::time::{Duration, sleep};
 


### PR DESCRIPTION
- Remove the 10-second timeout when reading JSON-RPC responses to prevent premature timeouts during long-running operations.

- The `select!` macro with timeout has been replaced with a direct async read_line call.

Closes #96