### PR TITLE
feat(viewer): add support for PDF, Excel, and image file viewing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,9 @@ frontend/dist/*
 frontend/*.local
 !frontend/dist/.gitkeep
 
+# PDF.js worker (auto-copied from node_modules)
+frontend/public/pdf.worker.min.mjs
+
 # Editor directories and files
 .vscode/*
 !.vscode/extensions.json

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -353,6 +353,7 @@ name = "backend"
 version = "0.3.0"
 dependencies = [
  "anyhow",
+ "base64 0.22.1",
  "cargo-tarpaulin",
  "chrono",
  "criterion",

--- a/crates/backend/Cargo.toml
+++ b/crates/backend/Cargo.toml
@@ -16,6 +16,7 @@ sha2 = "0.10"
 chrono = { version = "0.4", features = ["serde"] }
 regex = "1.0"
 ignore = "0.4"
+base64 = "0.22"
 proptest = { version = "1.0", optional = true }
 
 [target.'cfg(windows)'.dependencies]

--- a/crates/backend/src/lib.rs
+++ b/crates/backend/src/lib.rs
@@ -707,6 +707,11 @@ impl<E: EventEmitter + 'static> GeminiBackend<E> {
         filesystem::read_file_content(path).await
     }
 
+    /// Read binary file as base64 encoded string
+    pub async fn read_binary_file_as_base64(&self, path: String) -> Result<String> {
+        filesystem::read_binary_file_as_base64(path).await
+    }
+
     /// Get the canonical path for a given path
     pub async fn get_canonical_path(&self, path: String) -> Result<String> {
         let canonical_path = std::path::Path::new(&path)

--- a/crates/server/src/main.rs
+++ b/crates/server/src/main.rs
@@ -302,6 +302,12 @@ struct ReadFileContentRequest {
 
 #[derive(Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
+struct ReadBinaryFileAsBase64Request {
+    path: String,
+}
+
+#[derive(Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 struct CanonicalPathRequest {
     path: String,
 }
@@ -762,6 +768,20 @@ async fn read_file_content(
     ))
 }
 
+#[post("/read-binary-file-as-base64", data = "<request>")]
+async fn read_binary_file_as_base64(
+    request: Json<ReadBinaryFileAsBase64Request>,
+    state: &State<AppState>,
+) -> AppResult<Json<String>> {
+    let backend = state.backend.lock().await;
+    Ok(Json(
+        backend
+            .read_binary_file_as_base64(request.path.clone())
+            .await
+            .context("Failed to read binary file as base64")?,
+    ))
+}
+
 #[post("/get-canonical-path", data = "<request>")]
 async fn get_canonical_path(
     request: Json<CanonicalPathRequest>,
@@ -900,6 +920,7 @@ fn rocket() -> _ {
             get_detailed_conversation,
             export_conversation_history,
             read_file_content,
+            read_binary_file_as_base64,
             get_canonical_path,
             read_file_content_with_options,
             write_file_content,

--- a/crates/tauri-app/src/commands/mod.rs
+++ b/crates/tauri-app/src/commands/mod.rs
@@ -530,6 +530,18 @@ pub async fn read_file_content(
 }
 
 #[tauri::command]
+pub async fn read_binary_file_as_base64(
+    path: String,
+    state: State<'_, AppState>,
+) -> Result<String, String> {
+    state
+        .backend
+        .read_binary_file_as_base64(path)
+        .await
+        .map_err(|e| format!("{e:#}"))
+}
+
+#[tauri::command]
 pub async fn delete_conversation(
     chat_id: String,
     state: tauri::State<'_, AppState>,

--- a/crates/tauri-app/src/lib.rs
+++ b/crates/tauri-app/src/lib.rs
@@ -85,6 +85,7 @@ pub fn run() {
             commands::read_settings_file,
             commands::write_settings_file,
             commands::read_file_content,
+            commands::read_binary_file_as_base64,
             commands::get_canonical_path,
             commands::read_file_content_with_options,
             commands::write_file_content,

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -4,8 +4,9 @@
   "version": "0.3.0",
   "type": "module",
   "scripts": {
-    "dev": "vite",
-    "build": "tsc && vite build",
+    "dev": "npm run copy-pdf-worker && vite",
+    "build": "npm run copy-pdf-worker && tsc && vite build",
+    "copy-pdf-worker": "cp node_modules/pdfjs-dist/build/pdf.worker.min.mjs public/",
     "preview": "vite preview",
     "tauri": "tauri",
     "format": "pnpm prettier src --write",
@@ -59,12 +60,14 @@
     "katex": "^0.16.22",
     "lucide-react": "^0.540.0",
     "next-themes": "^0.4.6",
+    "pdfjs-dist": "5.3.93",
     "react": "^19.1.1",
     "react-diff-viewer-continued": "^3.4.0",
     "react-dom": "^19.1.1",
     "react-i18next": "^15.6.1",
     "react-markdown": "^10.1.0",
     "react-mentions": "^4.4.10",
+    "react-pdf": "^10.1.0",
     "react-router-dom": "^7.8.1",
     "react-syntax-highlighter": "^15.6.1",
     "rehype-highlight": "^7.0.2",
@@ -77,7 +80,8 @@
     "tailwind-merge": "^3.3.1",
     "tailwindcss": "^4.1.12",
     "tm-themes": "^1.10.7",
-    "unist-util-visit": "^5.0.0"
+    "unist-util-visit": "^5.0.0",
+    "xlsx": "^0.18.5"
   },
   "devDependencies": {
     "@eslint/js": "^9.33.0",

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -143,6 +143,9 @@ importers:
       next-themes:
         specifier: ^0.4.6
         version: 0.4.6(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
+      pdfjs-dist:
+        specifier: 5.3.93
+        version: 5.3.93
       react:
         specifier: ^19.1.1
         version: 19.1.1
@@ -161,6 +164,9 @@ importers:
       react-mentions:
         specifier: ^4.4.10
         version: 4.4.10(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
+      react-pdf:
+        specifier: ^10.1.0
+        version: 10.1.0(@types/react@19.1.10)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
       react-router-dom:
         specifier: ^7.8.1
         version: 7.8.1(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
@@ -200,6 +206,9 @@ importers:
       unist-util-visit:
         specifier: ^5.0.0
         version: 5.0.0
+      xlsx:
+        specifier: ^0.18.5
+        version: 0.18.5
     devDependencies:
       '@eslint/js':
         specifier: ^9.33.0
@@ -794,6 +803,70 @@ packages:
       monaco-editor: '>= 0.25.0 < 1'
       react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
       react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
+  '@napi-rs/canvas-android-arm64@0.1.78':
+    resolution: {integrity: sha512-N1ikxztjrRmh8xxlG5kYm1RuNr8ZW1EINEDQsLhhuy7t0pWI/e7SH91uFVLZKCMDyjel1tyWV93b5fdCAi7ggw==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [android]
+
+  '@napi-rs/canvas-darwin-arm64@0.1.78':
+    resolution: {integrity: sha512-FA3aCU3G5yGc74BSmnLJTObnZRV+HW+JBTrsU+0WVVaNyVKlb5nMvYAQuieQlRVemsAA2ek2c6nYtHh6u6bwFw==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@napi-rs/canvas-darwin-x64@0.1.78':
+    resolution: {integrity: sha512-xVij69o9t/frixCDEoyWoVDKgE3ksLGdmE2nvBWVGmoLu94MWUlv2y4Qzf5oozBmydG5Dcm4pRHFBM7YWa1i6g==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@napi-rs/canvas-linux-arm-gnueabihf@0.1.78':
+    resolution: {integrity: sha512-aSEXrLcIpBtXpOSnLhTg4jPsjJEnK7Je9KqUdAWjc7T8O4iYlxWxrXFIF8rV8J79h5jNdScgZpAUWYnEcutR3g==}
+    engines: {node: '>= 10'}
+    cpu: [arm]
+    os: [linux]
+
+  '@napi-rs/canvas-linux-arm64-gnu@0.1.78':
+    resolution: {integrity: sha512-dlEPRX1hLGKaY3UtGa1dtkA1uGgFITn2mDnfI6YsLlYyLJQNqHx87D1YTACI4zFCUuLr/EzQDzuX+vnp9YveVg==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@napi-rs/canvas-linux-arm64-musl@0.1.78':
+    resolution: {integrity: sha512-TsCfjOPZtm5Q/NO1EZHR5pwDPSPjPEttvnv44GL32Zn1uvudssjTLbvaG1jHq81Qxm16GTXEiYLmx4jOLZQYlg==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@napi-rs/canvas-linux-riscv64-gnu@0.1.78':
+    resolution: {integrity: sha512-+cpTTb0GDshEow/5Fy8TpNyzaPsYb3clQIjgWRmzRcuteLU+CHEU/vpYvAcSo7JxHYPJd8fjSr+qqh+nI5AtmA==}
+    engines: {node: '>= 10'}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@napi-rs/canvas-linux-x64-gnu@0.1.78':
+    resolution: {integrity: sha512-wxRcvKfvYBgtrO0Uy8OmwvjlnTcHpY45LLwkwVNIWHPqHAsyoTyG/JBSfJ0p5tWRzMOPDCDqdhpIO4LOgXjeyg==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+
+  '@napi-rs/canvas-linux-x64-musl@0.1.78':
+    resolution: {integrity: sha512-vQFOGwC9QDP0kXlhb2LU1QRw/humXgcbVp8mXlyBqzc/a0eijlLF9wzyarHC1EywpymtS63TAj8PHZnhTYN6hg==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+
+  '@napi-rs/canvas-win32-x64-msvc@0.1.78':
+    resolution: {integrity: sha512-/eKlTZBtGUgpRKalzOzRr6h7KVSuziESWXgBcBnXggZmimwIJWPJlEcbrx5Tcwj8rPuZiANXQOG9pPgy9Q4LTQ==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [win32]
+
+  '@napi-rs/canvas@0.1.78':
+    resolution: {integrity: sha512-YaBHJvT+T1DoP16puvWM6w46Lq3VhwKIJ8th5m1iEJyGh7mibk5dT7flBvMQ1EH1LYmMzXJ+OUhu+8wQ9I6u7g==}
+    engines: {node: '>= 10'}
 
   '@nodelib/fs.scandir@2.1.5':
     resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
@@ -1819,6 +1892,10 @@ packages:
     engines: {node: '>=0.4.0'}
     hasBin: true
 
+  adler-32@1.3.1:
+    resolution: {integrity: sha512-ynZ4w/nUUv5rrsR8UUGoe1VC9hZj6V5hU9Qw1HlMDJGEJw5S7TfTErWTjMys6M7vr0YWcPqs3qAr4ss0nDfP+A==}
+    engines: {node: '>=0.8'}
+
   ajv@6.12.6:
     resolution: {integrity: sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==}
 
@@ -1878,6 +1955,10 @@ packages:
   ccount@2.0.1:
     resolution: {integrity: sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==}
 
+  cfb@1.2.2:
+    resolution: {integrity: sha512-KfdUZsSOw19/ObEWasvBP/Ac4reZvAGauZhs6S/gqNhXhI7cKwvlH7ulj+dOEYnca4bm4SGo8C1bTAQvnTjgQA==}
+    engines: {node: '>=0.8'}
+
   chalk@4.1.2:
     resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
     engines: {node: '>=10'}
@@ -1926,6 +2007,10 @@ packages:
   codemirror@6.0.2:
     resolution: {integrity: sha512-VhydHotNW5w1UGK0Qj96BwSk/Zqbp9WbnyK2W/eVMv4QyF41INRGpjUhFJY7/uDNuudSc33a/PKr4iDqRduvHw==}
 
+  codepage@1.15.0:
+    resolution: {integrity: sha512-3g6NUTPd/YtuuGrhMnOMRjFc+LJw/bnMp3+0r/Wcz3IXUuCosKRJvMphm5+Q+bvTVGcJJuRvVLuYba+WojaFaA==}
+    engines: {node: '>=0.8'}
+
   color-convert@2.0.1:
     resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
     engines: {node: '>=7.0.0'}
@@ -1963,6 +2048,11 @@ packages:
   cosmiconfig@7.1.0:
     resolution: {integrity: sha512-AdmX6xUzdNASswsFtmwSt7Vj8po9IuqXm0UXz7QKPuEUmPB4XyjGfaAr2PSuELMwkRMVH1EpIkX5bTZGRB3eCA==}
     engines: {node: '>=10'}
+
+  crc-32@1.2.2:
+    resolution: {integrity: sha512-ROmzCKrTnOwybPcJApAA6WBWij23HVfGVNKqqrZpuyZOHqK2CwHSvpGuyt/UNNvaIjEd8X5IFGp4Mh+Ie1IHJQ==}
+    engines: {node: '>=0.8'}
+    hasBin: true
 
   crelt@1.0.6:
     resolution: {integrity: sha512-VQ2MBenTq1fWZUH9DJNGti7kKv6EeAuYr3cLwxUWhIu1baTaXh4Ib5W2CqHVqib4/MqbYGJqiL3Zb8GJZr3l4g==}
@@ -2195,6 +2285,10 @@ packages:
   format@0.2.2:
     resolution: {integrity: sha512-wzsgA6WOq+09wrU1tsJ09udeR/YZRaeArL9e1wPbFg3GG2yDnC2ldKpxs4xunpFF9DgqCqOIra3bc1HWrJ37Ww==}
     engines: {node: '>=0.4.x'}
+
+  frac@1.1.2:
+    resolution: {integrity: sha512-w/XBfkibaTl3YDqASwfDUqkna4Z2p9cFSr1aHDt0WoMTECnRfBOv2WArlZILlqgWlmdIlALXGpM2AOhEk5W3IA==}
+    engines: {node: '>=0.8'}
 
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
@@ -2560,6 +2654,12 @@ packages:
   magic-string@0.30.17:
     resolution: {integrity: sha512-sNPKHvyjVf7gyjwS4xGTaW/mCnF8wnjtifKBEhxfZ7E/S8tQ0rssrwGNn6q8JH/ohItJfSQp9mBtQYuTlH5QnA==}
 
+  make-cancellable-promise@2.0.0:
+    resolution: {integrity: sha512-3SEQqTpV9oqVsIWqAcmDuaNeo7yBO3tqPtqGRcKkEo0lrzD3wqbKG9mkxO65KoOgXqj+zH2phJ2LiAsdzlogSw==}
+
+  make-event-props@2.0.0:
+    resolution: {integrity: sha512-G/hncXrl4Qt7mauJEXSg3AcdYzmpkIITTNl5I+rH9sog5Yw0kK6vseJjCaPfOXqOqQuPUP89Rkhfz5kPS8ijtw==}
+
   markdown-table@3.0.4:
     resolution: {integrity: sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw==}
 
@@ -2617,6 +2717,14 @@ packages:
 
   memoize-one@6.0.0:
     resolution: {integrity: sha512-rkpe71W0N0c0Xz6QD0eJETuWAJGnJ9afsl1srmwPrI+yBCkge5EycXXbYRyvL29zZVUWQCY7InPRCv3GDXuZNw==}
+
+  merge-refs@2.0.0:
+    resolution: {integrity: sha512-3+B21mYK2IqUWnd2EivABLT7ueDhb0b8/dGK8LoFQPrU61YITeCMn14F7y7qZafWNZhUEKb24cJdiT5Wxs3prg==}
+    peerDependencies:
+      '@types/react': ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
 
   merge2@1.4.1:
     resolution: {integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==}
@@ -2827,6 +2935,10 @@ packages:
     resolution: {integrity: sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==}
     engines: {node: '>=8'}
 
+  pdfjs-dist@5.3.93:
+    resolution: {integrity: sha512-w3fQKVL1oGn8FRyx5JUG5tnbblggDqyx2XzA5brsJ5hSuS+I0NdnJANhmeWKLjotdbPQucLBug5t0MeWr0AAdg==}
+    engines: {node: '>=20.16.0 || >=22.3.0'}
+
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
 
@@ -2927,6 +3039,16 @@ packages:
     peerDependencies:
       react: '>=16.8.3'
       react-dom: '>=16.8.3'
+
+  react-pdf@10.1.0:
+    resolution: {integrity: sha512-iUI1YqWgwwZcsXjrehTp3Yi8nT/bvTaWULaRMMyJWvoqqSlopk4LQQ9GDqUnDtX3gzT2glrqrLbjIPl56a+Q3w==}
+    peerDependencies:
+      '@types/react': ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
 
   react-refresh@0.17.0:
     resolution: {integrity: sha512-z6F7K9bV85EfseRCp2bzrpyQ0Gkw1uLoCel9XBVWPg/TjRj94SkJzUTGfOa4bs7iJvBWtQG0Wq7wnI0syw3EBQ==}
@@ -3094,6 +3216,10 @@ packages:
   space-separated-tokens@2.0.2:
     resolution: {integrity: sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==}
 
+  ssf@0.11.2:
+    resolution: {integrity: sha512-+idbmIXoYET47hH+d7dfm2epdOMUDjqcB4648sTZ+t2JwoyBFL/insLfB/racrDmsKB3diwsDA696pZMieAC5g==}
+    engines: {node: '>=0.8'}
+
   state-local@1.0.7:
     resolution: {integrity: sha512-HTEHMNieakEnoe33shBYcZ7NX83ACUjCu8c40iOGEZsngj9zRnkqS9j1pqQPXwobB0ZcVTk27REb7COQ0UR59w==}
 
@@ -3142,6 +3268,9 @@ packages:
   tar@7.4.3:
     resolution: {integrity: sha512-5S7Va8hKfV7W5U6g3aYxXmlPoZVAwUMy9AOKyF2fVuZa2UD3qZjg578OrLRt8PcNN1PleVaL/5/yYATNL0ICUw==}
     engines: {node: '>=18'}
+
+  tiny-invariant@1.3.3:
+    resolution: {integrity: sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==}
 
   tinyglobby@0.2.14:
     resolution: {integrity: sha512-tX5e7OM1HnYr2+a2C/4V0htOcSQcoSTH9KgJnVvNm5zm/cyEWKJ7j7YutsH9CxMdtOkkLFy2AHrMci9IM8IPZQ==}
@@ -3304,6 +3433,9 @@ packages:
   w3c-keyname@2.2.8:
     resolution: {integrity: sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ==}
 
+  warning@4.0.3:
+    resolution: {integrity: sha512-rpJyN222KWIvHJ/F53XSZv0Zl/accqHR8et1kpaMTD/fLCRxtV8iX8czMzY7sVZupTI3zcUTg8eycS2kNF9l6w==}
+
   web-namespaces@2.0.1:
     resolution: {integrity: sha512-bKr1DkiNa2krS7qxNtdrtHAmzuYGFQLiQ13TsorsdT6ULTkPLKuu5+GsFpDlg6JFjUTwX2DyhMPG2be8uPrqsQ==}
 
@@ -3318,9 +3450,22 @@ packages:
     engines: {node: '>= 8'}
     hasBin: true
 
+  wmf@1.0.2:
+    resolution: {integrity: sha512-/p9K7bEh0Dj6WbXg4JG0xvLQmIadrner1bi45VMJTfnbVHsc7yIajZyoSoK60/dtVBs12Fm6WkUI5/3WAVsNMw==}
+    engines: {node: '>=0.8'}
+
   word-wrap@1.2.5:
     resolution: {integrity: sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==}
     engines: {node: '>=0.10.0'}
+
+  word@0.3.0:
+    resolution: {integrity: sha512-OELeY0Q61OXpdUfTp+oweA/vtLVg5VDOXh+3he3PNzLGG/y0oylSOC1xRVj0+l4vQ3tj/bB1HVHv1ocXkQceFA==}
+    engines: {node: '>=0.8'}
+
+  xlsx@0.18.5:
+    resolution: {integrity: sha512-dmg3LCjBPHZnQp5/F/+nnTa+miPJxUXB6vtk42YjBBKayDNagxGEeIdWApkYPOf3Z3pm3k62Knjzp7lMeTEtFQ==}
+    engines: {node: '>=0.8'}
+    hasBin: true
 
   xtend@4.0.2:
     resolution: {integrity: sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==}
@@ -4063,6 +4208,50 @@ snapshots:
       monaco-editor: 0.52.2
       react: 19.1.1
       react-dom: 19.1.1(react@19.1.1)
+
+  '@napi-rs/canvas-android-arm64@0.1.78':
+    optional: true
+
+  '@napi-rs/canvas-darwin-arm64@0.1.78':
+    optional: true
+
+  '@napi-rs/canvas-darwin-x64@0.1.78':
+    optional: true
+
+  '@napi-rs/canvas-linux-arm-gnueabihf@0.1.78':
+    optional: true
+
+  '@napi-rs/canvas-linux-arm64-gnu@0.1.78':
+    optional: true
+
+  '@napi-rs/canvas-linux-arm64-musl@0.1.78':
+    optional: true
+
+  '@napi-rs/canvas-linux-riscv64-gnu@0.1.78':
+    optional: true
+
+  '@napi-rs/canvas-linux-x64-gnu@0.1.78':
+    optional: true
+
+  '@napi-rs/canvas-linux-x64-musl@0.1.78':
+    optional: true
+
+  '@napi-rs/canvas-win32-x64-msvc@0.1.78':
+    optional: true
+
+  '@napi-rs/canvas@0.1.78':
+    optionalDependencies:
+      '@napi-rs/canvas-android-arm64': 0.1.78
+      '@napi-rs/canvas-darwin-arm64': 0.1.78
+      '@napi-rs/canvas-darwin-x64': 0.1.78
+      '@napi-rs/canvas-linux-arm-gnueabihf': 0.1.78
+      '@napi-rs/canvas-linux-arm64-gnu': 0.1.78
+      '@napi-rs/canvas-linux-arm64-musl': 0.1.78
+      '@napi-rs/canvas-linux-riscv64-gnu': 0.1.78
+      '@napi-rs/canvas-linux-x64-gnu': 0.1.78
+      '@napi-rs/canvas-linux-x64-musl': 0.1.78
+      '@napi-rs/canvas-win32-x64-msvc': 0.1.78
+    optional: true
 
   '@nodelib/fs.scandir@2.1.5':
     dependencies:
@@ -5293,6 +5482,8 @@ snapshots:
 
   acorn@8.15.0: {}
 
+  adler-32@1.3.1: {}
+
   ajv@6.12.6:
     dependencies:
       fast-deep-equal: 3.1.3
@@ -5361,6 +5552,11 @@ snapshots:
 
   ccount@2.0.1: {}
 
+  cfb@1.2.2:
+    dependencies:
+      adler-32: 1.3.1
+      crc-32: 1.2.2
+
   chalk@4.1.2:
     dependencies:
       ansi-styles: 4.3.0
@@ -5412,6 +5608,8 @@ snapshots:
       '@codemirror/state': 6.5.2
       '@codemirror/view': 6.38.1
 
+  codepage@1.15.0: {}
+
   color-convert@2.0.1:
     dependencies:
       color-name: 1.1.4
@@ -5443,6 +5641,8 @@ snapshots:
       parse-json: 5.2.0
       path-type: 4.0.0
       yaml: 1.10.2
+
+  crc-32@1.2.2: {}
 
   crelt@1.0.6: {}
 
@@ -5695,6 +5895,8 @@ snapshots:
       mime-types: 2.1.35
 
   format@0.2.2: {}
+
+  frac@1.1.2: {}
 
   fsevents@2.3.3:
     optional: true
@@ -6089,6 +6291,10 @@ snapshots:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.4
 
+  make-cancellable-promise@2.0.0: {}
+
+  make-event-props@2.0.0: {}
+
   markdown-table@3.0.4: {}
 
   math-intrinsics@1.1.0: {}
@@ -6259,6 +6465,10 @@ snapshots:
       '@types/mdast': 4.0.4
 
   memoize-one@6.0.0: {}
+
+  merge-refs@2.0.0(@types/react@19.1.10):
+    optionalDependencies:
+      '@types/react': 19.1.10
 
   merge2@1.4.1: {}
 
@@ -6578,6 +6788,10 @@ snapshots:
 
   path-type@4.0.0: {}
 
+  pdfjs-dist@5.3.93:
+    optionalDependencies:
+      '@napi-rs/canvas': 0.1.78
+
   picocolors@1.1.1: {}
 
   picomatch@2.3.1: {}
@@ -6678,6 +6892,21 @@ snapshots:
       react: 19.1.1
       react-dom: 19.1.1(react@19.1.1)
       substyle: 9.4.1(react@19.1.1)
+
+  react-pdf@10.1.0(@types/react@19.1.10)(react-dom@19.1.1(react@19.1.1))(react@19.1.1):
+    dependencies:
+      clsx: 2.1.1
+      dequal: 2.0.3
+      make-cancellable-promise: 2.0.0
+      make-event-props: 2.0.0
+      merge-refs: 2.0.0(@types/react@19.1.10)
+      pdfjs-dist: 5.3.93
+      react: 19.1.1
+      react-dom: 19.1.1(react@19.1.1)
+      tiny-invariant: 1.3.3
+      warning: 4.0.3
+    optionalDependencies:
+      '@types/react': 19.1.10
 
   react-refresh@0.17.0: {}
 
@@ -6897,6 +7126,10 @@ snapshots:
 
   space-separated-tokens@2.0.2: {}
 
+  ssf@0.11.2:
+    dependencies:
+      frac: 1.1.2
+
   state-local@1.0.7: {}
 
   stringify-entities@4.0.4:
@@ -6944,6 +7177,8 @@ snapshots:
       minizlib: 3.0.2
       mkdirp: 3.0.1
       yallist: 5.0.0
+
+  tiny-invariant@1.3.3: {}
 
   tinyglobby@0.2.14:
     dependencies:
@@ -7085,6 +7320,10 @@ snapshots:
 
   w3c-keyname@2.2.8: {}
 
+  warning@4.0.3:
+    dependencies:
+      loose-envify: 1.4.0
+
   web-namespaces@2.0.1: {}
 
   webidl-conversions@3.0.1: {}
@@ -7098,7 +7337,21 @@ snapshots:
     dependencies:
       isexe: 2.0.0
 
+  wmf@1.0.2: {}
+
   word-wrap@1.2.5: {}
+
+  word@0.3.0: {}
+
+  xlsx@0.18.5:
+    dependencies:
+      adler-32: 1.3.1
+      cfb: 1.2.2
+      codepage: 1.15.0
+      crc-32: 1.2.2
+      ssf: 0.11.2
+      wmf: 1.0.2
+      word: 0.3.0
 
   xtend@4.0.2: {}
 

--- a/frontend/src/components/common/ExcelViewer.tsx
+++ b/frontend/src/components/common/ExcelViewer.tsx
@@ -1,0 +1,166 @@
+import { useState, useEffect } from "react";
+import * as XLSX from "xlsx";
+import { Table, TableHeader, TableRow, TableHead, TableBody, TableCell } from "../ui/table";
+import { ScrollArea } from "../ui/scroll-area";
+import { Badge } from "../ui/badge";
+import { FileSpreadsheet, AlertCircle } from "lucide-react";
+import { api } from "../../lib/api";
+
+interface ExcelViewerProps {
+  filePath: string;
+}
+
+export function ExcelViewer({ filePath }: ExcelViewerProps) {
+  const [workbook, setWorkbook] = useState<XLSX.WorkBook | null>(null);
+  const [activeSheet, setActiveSheet] = useState<string>("");
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const loadExcelFile = async () => {
+      setLoading(true);
+      setError(null);
+
+      try {
+        // Read the Excel file as binary
+        const base64Content = await api.read_binary_file_as_base64({ path: filePath });
+        
+        if (!base64Content) {
+          throw new Error("Failed to read file content");
+        }
+
+        // Convert base64 content to buffer for XLSX
+        const binaryString = atob(base64Content);
+        const bytes = new Uint8Array(binaryString.length);
+        for (let i = 0; i < binaryString.length; i++) {
+          bytes[i] = binaryString.charCodeAt(i);
+        }
+        
+        // Parse the Excel file
+        const wb = XLSX.read(bytes, { type: 'array' });
+        setWorkbook(wb);
+        
+        // Set the first sheet as active
+        if (wb.SheetNames.length > 0) {
+          setActiveSheet(wb.SheetNames[0]);
+        }
+      } catch (err) {
+        setError(err instanceof Error ? err.message : "Failed to load Excel file");
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    loadExcelFile();
+  }, [filePath]);
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center p-8">
+        <div className="flex items-center gap-3">
+          <FileSpreadsheet className="h-8 w-8 animate-pulse text-green-500" />
+          <span>Loading Excel file...</span>
+        </div>
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="flex items-center justify-center p-8 text-red-500">
+        <div className="flex items-center gap-3">
+          <AlertCircle className="h-8 w-8" />
+          <span>{error}</span>
+        </div>
+      </div>
+    );
+  }
+
+  if (!workbook || workbook.SheetNames.length === 0) {
+    return (
+      <div className="flex items-center justify-center p-8 text-muted-foreground">
+        <div className="flex items-center gap-3">
+          <FileSpreadsheet className="h-8 w-8" />
+          <span>No worksheets found</span>
+        </div>
+      </div>
+    );
+  }
+
+  const currentSheet = workbook.Sheets[activeSheet];
+  const jsonData = XLSX.utils.sheet_to_json<string[]>(currentSheet, { 
+    header: 1,
+    raw: false,
+    defval: ""
+  });
+
+  // Get the maximum number of columns
+  const maxCols = Math.max(...jsonData.map(row => row.length));
+  
+  // Create column headers
+  const headers = Array.from({ length: maxCols }, (_, i) => 
+    XLSX.utils.encode_col(i)
+  );
+
+  return (
+    <div className="flex flex-col h-full">
+      {/* Sheet selector */}
+      {workbook.SheetNames.length > 1 && (
+        <div className="flex items-center gap-2 p-3 border-b">
+          <FileSpreadsheet className="h-4 w-4 text-green-500" />
+          <span className="text-sm font-medium">Worksheets:</span>
+          <div className="flex gap-1 flex-wrap">
+            {workbook.SheetNames.map((sheetName) => (
+              <Badge
+                key={sheetName}
+                variant={sheetName === activeSheet ? "default" : "outline"}
+                className="cursor-pointer text-xs"
+                onClick={() => setActiveSheet(sheetName)}
+              >
+                {sheetName}
+              </Badge>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {/* Table */}
+      <ScrollArea className="flex-1">
+        <div className="p-3">
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead className="w-12 text-center font-mono text-xs sticky left-0 bg-background">#</TableHead>
+                {headers.map((header) => (
+                  <TableHead key={header} className="text-center font-mono text-xs min-w-24">
+                    {header}
+                  </TableHead>
+                ))}
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {jsonData.map((row, rowIndex) => (
+                <TableRow key={rowIndex}>
+                  <TableCell className="text-center font-mono text-xs bg-muted/50 sticky left-0">
+                    {rowIndex + 1}
+                  </TableCell>
+                  {headers.map((_, colIndex) => (
+                    <TableCell key={colIndex} className="text-xs max-w-48 truncate" title={row[colIndex] || ""}>
+                      {row[colIndex] || ""}
+                    </TableCell>
+                  ))}
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        </div>
+      </ScrollArea>
+
+      {/* Footer info */}
+      <div className="p-2 border-t bg-muted/30 text-xs text-muted-foreground flex justify-between">
+        <span>Sheet: {activeSheet}</span>
+        <span>{jsonData.length} rows × {maxCols} columns</span>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/common/FileContentViewer.tsx
+++ b/frontend/src/components/common/FileContentViewer.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from "react";
+import { useState, useEffect, useCallback } from "react";
 import { FileText, Copy, Download, Edit, Save, X } from "lucide-react";
 import { useTranslation } from "react-i18next";
 import { Button } from "../ui/button";
@@ -7,6 +7,9 @@ import { Badge } from "../ui/badge";
 import { Skeleton } from "../ui/skeleton";
 import { api } from "../../lib/api";
 import { CodeMirrorViewer } from "./CodeMirrorViewer";
+import { ExcelViewer } from "./ExcelViewer";
+import { PDFViewer } from "./PDFViewer";
+import { ImageViewer } from "./ImageViewer";
 
 interface FileContentViewerProps {
   filePath: string | null;
@@ -40,11 +43,56 @@ export function FileContentViewer({
 
   const isOpen = filePath !== null;
 
+  const getFileExtension = (path: string): string => {
+    return path.split(".").pop()?.toLowerCase() || "";
+  };
+
+  const getFileType = useCallback((path: string): 'excel' | 'pdf' | 'image' | 'text' => {
+    const ext = getFileExtension(path);
+    
+    // Excel files
+    if (['xlsx', 'xls', 'xlsm', 'xlsb', 'csv'].includes(ext)) {
+      return 'excel';
+    }
+    
+    // PDF files
+    if (ext === 'pdf') {
+      return 'pdf';
+    }
+    
+    // Image files
+    if (['png', 'jpg', 'jpeg', 'gif', 'webp', 'svg', 'bmp', 'ico'].includes(ext)) {
+      return 'image';
+    }
+    
+    // Default to text
+    return 'text';
+  }, []);
+
   useEffect(() => {
     if (!filePath) {
       setFileContent(null);
       setError(null);
       setForceViewAsText(false);
+      return;
+    }
+
+    const fileType = getFileType(filePath);
+    
+    // For specialized file types (excel, pdf, image), we don't need to load content
+    // The specialized viewers will handle their own loading
+    if (fileType !== 'text') {
+      setFileContent({
+        path: filePath,
+        content: null,
+        size: 0,
+        modified: null,
+        encoding: 'binary',
+        is_text: false,
+        is_binary: true,
+        error: null,
+      });
+      setLoading(false);
       return;
     }
 
@@ -74,7 +122,7 @@ export function FileContentViewer({
     };
 
     loadFileContent();
-  }, [filePath, forceViewAsText]);
+  }, [filePath, forceViewAsText, getFileType]);
 
   const handleEdit = () => {
     if (
@@ -168,10 +216,6 @@ export function FileContentViewer({
     return new Date(timestamp * 1000).toLocaleString();
   };
 
-  const getFileExtension = (path: string): string => {
-    return path.split(".").pop()?.toLowerCase() || "";
-  };
-
   const getLanguageFromExtension = (path: string): string => {
     const ext = getFileExtension(path);
     const languageMap: Record<string, string> = {
@@ -204,7 +248,7 @@ export function FileContentViewer({
 
   return (
     <Dialog open={isOpen} onOpenChange={onClose}>
-      <DialogContent className="max-w-4xl max-h-[80vh] flex flex-col">
+      <DialogContent className={`max-w-4xl flex flex-col ${getFileType(filePath || '') === 'pdf' ? 'max-h-[95vh]' : 'max-h-[80vh]'}`}>
         <DialogHeader className="flex-shrink-0">
           <DialogTitle className="flex items-center gap-2">
             <FileText className="h-5 w-5 text-blue-500 flex-shrink-0" />
@@ -246,136 +290,164 @@ export function FileContentViewer({
             </div>
           ) : fileContent ? (
             <>
-              {/* File actions bar */}
-              <div className="flex items-center justify-between px-3 py-2 border-b bg-muted/50 rounded-md mx-2 mb-2">
-                <div className="flex items-center gap-2 text-xs text-muted-foreground">
-                  <span>{fileContent.encoding}</span>
-                  <Badge
-                    variant={
-                      fileContent.is_binary && forceViewAsText
-                        ? "destructive"
-                        : fileContent.is_text
-                          ? "default"
-                          : "secondary"
-                    }
-                    className="text-xs px-1.5 py-0.5"
-                  >
-                    {fileContent.is_binary && forceViewAsText
-                      ? "Binary (forced as text)"
-                      : fileContent.is_text
-                        ? "Text"
-                        : "Binary"}
-                  </Badge>
-                  {fileContent.is_binary && forceViewAsText && (
-                    <Button
-                      variant="ghost"
-                      size="sm"
-                      onClick={() => setForceViewAsText(false)}
-                      className="text-xs h-6 px-2 text-muted-foreground hover:text-foreground"
+              {/* File actions bar - only show for text files */}
+              {getFileType(fileContent.path) === 'text' && (
+                <div className="flex items-center justify-between px-3 py-2 border-b bg-muted/50 rounded-md mx-2 mb-2">
+                  <div className="flex items-center gap-2 text-xs text-muted-foreground">
+                    <span>{fileContent.encoding}</span>
+                    <Badge
+                      variant={
+                        fileContent.is_binary && forceViewAsText
+                          ? "destructive"
+                          : fileContent.is_text
+                            ? "default"
+                            : "secondary"
+                      }
+                      className="text-xs px-1.5 py-0.5"
                     >
-                      Back to binary view
-                    </Button>
-                  )}
-                </div>
-
-                <div className="flex items-center gap-1">
-                  {(fileContent.is_text ||
-                    (fileContent.is_binary && forceViewAsText)) &&
-                    fileContent.content !== null && (
-                      <>
-                        {!isEditing ? (
-                          <>
-                            <Button
-                              variant="ghost"
-                              size="sm"
-                              onClick={handleEdit}
-                              className="text-xs h-7 px-2"
-                            >
-                              <Edit className="h-3.5 w-3.5 mr-1" />
-                              Edit
-                            </Button>
-                            <Button
-                              variant="ghost"
-                              size="sm"
-                              onClick={handleCopy}
-                              className="text-xs h-7 px-2"
-                            >
-                              <Copy className="h-3.5 w-3.5 mr-1" />
-                              {copied ? t("common.copied") : t("common.copy")}
-                            </Button>
-                            <Button
-                              variant="ghost"
-                              size="sm"
-                              onClick={handleDownload}
-                              className="text-xs h-7 px-2"
-                            >
-                              <Download className="h-3.5 w-3.5 mr-1" />
-                              Download
-                            </Button>
-                          </>
-                        ) : (
-                          <>
-                            <Button
-                              variant="default"
-                              size="sm"
-                              onClick={handleSave}
-                              disabled={saving}
-                              className="text-xs h-7 px-2"
-                            >
-                              <Save className="h-3.5 w-3.5 mr-1" />
-                              {saving ? "Saving..." : "Save"}
-                            </Button>
-                            <Button
-                              variant="ghost"
-                              size="sm"
-                              onClick={handleCancel}
-                              disabled={saving}
-                              className="text-xs h-7 px-2"
-                            >
-                              <X className="h-3.5 w-3.5 mr-1" />
-                              Cancel
-                            </Button>
-                          </>
-                        )}
-                      </>
+                      {fileContent.is_binary && forceViewAsText
+                        ? "Binary (forced as text)"
+                        : fileContent.is_text
+                          ? "Text"
+                          : "Binary"}
+                    </Badge>
+                    {fileContent.is_binary && forceViewAsText && (
+                      <Button
+                        variant="ghost"
+                        size="sm"
+                        onClick={() => setForceViewAsText(false)}
+                        className="text-xs h-6 px-2 text-muted-foreground hover:text-foreground"
+                      >
+                        Back to binary view
+                      </Button>
                     )}
+                  </div>
+
+                  <div className="flex items-center gap-1">
+                    {(fileContent.is_text ||
+                      (fileContent.is_binary && forceViewAsText)) &&
+                      fileContent.content !== null && (
+                        <>
+                          {!isEditing ? (
+                            <>
+                              <Button
+                                variant="ghost"
+                                size="sm"
+                                onClick={handleEdit}
+                                className="text-xs h-7 px-2"
+                              >
+                                <Edit className="h-3.5 w-3.5 mr-1" />
+                                Edit
+                              </Button>
+                              <Button
+                                variant="ghost"
+                                size="sm"
+                                onClick={handleCopy}
+                                className="text-xs h-7 px-2"
+                              >
+                                <Copy className="h-3.5 w-3.5 mr-1" />
+                                {copied ? t("common.copied") : t("common.copy")}
+                              </Button>
+                              <Button
+                                variant="ghost"
+                                size="sm"
+                                onClick={handleDownload}
+                                className="text-xs h-7 px-2"
+                              >
+                                <Download className="h-3.5 w-3.5 mr-1" />
+                                Download
+                              </Button>
+                            </>
+                          ) : (
+                            <>
+                              <Button
+                                variant="default"
+                                size="sm"
+                                onClick={handleSave}
+                                disabled={saving}
+                                className="text-xs h-7 px-2"
+                              >
+                                <Save className="h-3.5 w-3.5 mr-1" />
+                                {saving ? "Saving..." : "Save"}
+                              </Button>
+                              <Button
+                                variant="ghost"
+                                size="sm"
+                                onClick={handleCancel}
+                                disabled={saving}
+                                className="text-xs h-7 px-2"
+                              >
+                                <X className="h-3.5 w-3.5 mr-1" />
+                                Cancel
+                              </Button>
+                            </>
+                          )}
+                        </>
+                      )}
+                  </div>
                 </div>
-              </div>
+              )}
 
               {/* File content */}
-              <div className="flex-1 overflow-hidden">
-                {fileContent.is_binary && !forceViewAsText ? (
-                  <div className="text-center py-8 text-muted-foreground">
-                    <FileText className="h-12 w-12 mx-auto mb-4 opacity-50" />
-                    <p>
-                      This is a binary file and cannot be displayed as text.
-                    </p>
-                    <p className="text-sm mt-2 mb-4">
-                      Size: {formatFileSize(fileContent.size)}
-                    </p>
-                    <Button
-                      variant="outline"
-                      onClick={() => setForceViewAsText(true)}
-                      className="text-sm"
-                    >
-                      View anyway
-                    </Button>
-                  </div>
-                ) : fileContent.content !== null ? (
-                  <div className="h-full overflow-auto">
-                    <CodeMirrorViewer
-                      code={isEditing ? editedContent : fileContent.content}
-                      language={getLanguageFromExtension(fileContent.path)}
-                      readOnly={!isEditing}
-                      onChange={isEditing ? setEditedContent : undefined}
-                    />
-                  </div>
-                ) : (
-                  <div className="text-center py-8 text-muted-foreground">
-                    <FileText className="h-12 w-12 mx-auto mb-4 opacity-50" />
-                    <p>File is empty or content could not be read.</p>
-                  </div>
-                )}
+              <div className="flex-1 min-h-0 overflow-hidden">
+                {(() => {
+                  const fileType = getFileType(fileContent.path);
+                  
+                  // Handle specialized file types
+                  if (fileType === 'excel') {
+                    return <ExcelViewer filePath={fileContent.path} />;
+                  }
+                  
+                  if (fileType === 'pdf') {
+                    return <PDFViewer filePath={fileContent.path} />;
+                  }
+                  
+                  if (fileType === 'image') {
+                    return <ImageViewer filePath={fileContent.path} />;
+                  }
+                  
+                  // Handle text files and binary files
+                  if (fileContent.is_binary && !forceViewAsText) {
+                    return (
+                      <div className="text-center py-8 text-muted-foreground">
+                        <FileText className="h-12 w-12 mx-auto mb-4 opacity-50" />
+                        <p>
+                          This is a binary file and cannot be displayed as text.
+                        </p>
+                        <p className="text-sm mt-2 mb-4">
+                          Size: {formatFileSize(fileContent.size)}
+                        </p>
+                        <Button
+                          variant="outline"
+                          onClick={() => setForceViewAsText(true)}
+                          className="text-sm"
+                        >
+                          View anyway
+                        </Button>
+                      </div>
+                    );
+                  }
+                  
+                  if (fileContent.content !== null) {
+                    return (
+                      <div className="h-full overflow-auto">
+                        <CodeMirrorViewer
+                          code={isEditing ? editedContent : fileContent.content}
+                          language={getLanguageFromExtension(fileContent.path)}
+                          readOnly={!isEditing}
+                          onChange={isEditing ? setEditedContent : undefined}
+                        />
+                      </div>
+                    );
+                  }
+                  
+                  return (
+                    <div className="text-center py-8 text-muted-foreground">
+                      <FileText className="h-12 w-12 mx-auto mb-4 opacity-50" />
+                      <p>File is empty or content could not be read.</p>
+                    </div>
+                  );
+                })()}
               </div>
             </>
           ) : null}

--- a/frontend/src/components/common/ImageViewer.tsx
+++ b/frontend/src/components/common/ImageViewer.tsx
@@ -1,0 +1,227 @@
+import { useState, useEffect } from "react";
+import { ZoomIn, ZoomOut, RotateCw, Image as ImageIcon, AlertCircle, Download } from "lucide-react";
+import { Button } from "../ui/button";
+import { Badge } from "../ui/badge";
+import { ScrollArea } from "../ui/scroll-area";
+import { api } from "../../lib/api";
+
+interface ImageViewerProps {
+  filePath: string;
+}
+
+export function ImageViewer({ filePath }: ImageViewerProps) {
+  const [scale, setScale] = useState(1.0);
+  const [rotation, setRotation] = useState(0);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [imageData, setImageData] = useState<string | null>(null);
+  const [imageInfo, setImageInfo] = useState<{
+    width: number;
+    height: number;
+    size: number;
+  } | null>(null);
+
+  useEffect(() => {
+    const loadImageFile = async () => {
+      setLoading(true);
+      setError(null);
+
+      try {
+        const base64Content = await api.read_binary_file_as_base64({ path: filePath });
+        
+        if (!base64Content) {
+          throw new Error("Failed to read image file");
+        }
+
+        // Get file extension to determine MIME type
+        const ext = filePath.split('.').pop()?.toLowerCase();
+        const mimeType = ext === 'png' ? 'image/png' : 
+                        ext === 'jpg' || ext === 'jpeg' ? 'image/jpeg' :
+                        ext === 'gif' ? 'image/gif' :
+                        ext === 'webp' ? 'image/webp' :
+                        ext === 'svg' ? 'image/svg+xml' : 'image/png';
+
+        // Create data URL from base64 content
+        const dataUrl = `data:${mimeType};base64,${base64Content}`;
+        setImageData(dataUrl);
+
+        // Get image dimensions and size
+        const img = new Image();
+        img.onload = () => {
+          // Calculate approximate file size from base64 length
+          const approximateSize = Math.round((base64Content.length * 3) / 4);
+          setImageInfo({
+            width: img.width,
+            height: img.height,
+            size: approximateSize
+          });
+        };
+        img.src = dataUrl;
+
+      } catch (err) {
+        setError(err instanceof Error ? err.message : "Failed to load image file");
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    loadImageFile();
+  }, [filePath]);
+
+  const zoomIn = () => {
+    setScale(prev => Math.min(5.0, prev + 0.25));
+  };
+
+  const zoomOut = () => {
+    setScale(prev => Math.max(0.1, prev - 0.25));
+  };
+
+  const resetZoom = () => {
+    setScale(1.0);
+  };
+
+  const rotate = () => {
+    setRotation(prev => (prev + 90) % 360);
+  };
+
+  const handleDownload = () => {
+    if (!imageData) return;
+
+    const fileName = filePath.split('/').pop() || 'image.png';
+    const link = document.createElement('a');
+    link.href = imageData;
+    link.download = fileName;
+    document.body.appendChild(link);
+    link.click();
+    document.body.removeChild(link);
+  };
+
+  const formatFileSize = (bytes: number): string => {
+    if (bytes === 0) return "0 B";
+    const units = ["B", "KB", "MB", "GB"];
+    let size = bytes;
+    let unitIndex = 0;
+
+    while (size >= 1024 && unitIndex < units.length - 1) {
+      size /= 1024;
+      unitIndex++;
+    }
+
+    return `${size.toFixed(unitIndex > 0 ? 1 : 0)} ${units[unitIndex]}`;
+  };
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center p-8">
+        <div className="flex items-center gap-3">
+          <ImageIcon className="h-8 w-8 animate-pulse text-blue-500" />
+          <span>Loading image...</span>
+        </div>
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="flex items-center justify-center p-8 text-red-500">
+        <div className="flex items-center gap-3">
+          <AlertCircle className="h-8 w-8" />
+          <span>{error}</span>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex flex-col h-full">
+      {/* Controls */}
+      <div className="flex items-center justify-between p-3 border-b bg-muted/30">
+        <div className="flex items-center gap-2">
+          <ImageIcon className="h-4 w-4 text-blue-500" />
+          <span className="text-sm font-medium">Image Viewer</span>
+          {imageInfo && (
+            <div className="flex items-center gap-2 text-xs text-muted-foreground">
+              <Badge variant="secondary" className="text-xs px-1.5 py-0">
+                {imageInfo.width} × {imageInfo.height}
+              </Badge>
+              <Badge variant="secondary" className="text-xs px-1.5 py-0">
+                {formatFileSize(imageInfo.size)}
+              </Badge>
+            </div>
+          )}
+        </div>
+        
+        <div className="flex items-center gap-2">
+          {/* Zoom controls */}
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={zoomOut}
+            disabled={scale <= 0.1}
+            className="h-7 w-7 p-0"
+          >
+            <ZoomOut className="h-3.5 w-3.5" />
+          </Button>
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={resetZoom}
+            className="text-xs h-7 px-2"
+          >
+            {Math.round(scale * 100)}%
+          </Button>
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={zoomIn}
+            disabled={scale >= 5.0}
+            className="h-7 w-7 p-0"
+          >
+            <ZoomIn className="h-3.5 w-3.5" />
+          </Button>
+
+          <div className="w-px h-4 bg-border mx-1" />
+
+          {/* Rotation */}
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={rotate}
+            className="h-7 w-7 p-0"
+          >
+            <RotateCw className="h-3.5 w-3.5" />
+          </Button>
+
+          <div className="w-px h-4 bg-border mx-1" />
+
+          {/* Download */}
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={handleDownload}
+            className="h-7 w-7 p-0"
+          >
+            <Download className="h-3.5 w-3.5" />
+          </Button>
+        </div>
+      </div>
+
+      {/* Image Content */}
+      <ScrollArea className="flex-1 bg-gray-50 dark:bg-gray-950">
+        <div className="flex items-center justify-center min-h-full p-4">
+          {imageData && (
+            <img
+              src={imageData}
+              alt={filePath.split('/').pop() || 'Image'}
+              className="max-w-none shadow-lg"
+              style={{
+                transform: `scale(${scale}) rotate(${rotation}deg)`,
+                transition: 'transform 0.2s ease-in-out',
+              }}
+            />
+          )}
+        </div>
+      </ScrollArea>
+    </div>
+  );
+}

--- a/frontend/src/components/common/PDFViewer.tsx
+++ b/frontend/src/components/common/PDFViewer.tsx
@@ -1,0 +1,175 @@
+import { useState, useEffect } from "react";
+import { Document, Page, pdfjs } from "react-pdf";
+import { ZoomIn, ZoomOut, FileText, AlertCircle } from "lucide-react";
+import { Button } from "../ui/button";
+import { Badge } from "../ui/badge";
+import { api } from "../../lib/api";
+
+// Configure PDF.js worker to use local version instead of CDN to avoid CORS issues
+// Serve worker from public directory (copied during build)
+pdfjs.GlobalWorkerOptions.workerSrc = '/pdf.worker.min.mjs';
+
+interface PDFViewerProps {
+  filePath: string;
+}
+
+export function PDFViewer({ filePath }: PDFViewerProps) {
+  const [numPages, setNumPages] = useState<number | null>(null);
+  const [scale, setScale] = useState(1.0);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [pdfFile, setPdfFile] = useState<string | null>(null);
+
+  useEffect(() => {
+    const loadPDFFile = async () => {
+      setLoading(true);
+      setError(null);
+
+      try {
+        const base64Content = await api.read_binary_file_as_base64({ path: filePath });
+        
+        if (!base64Content) {
+          throw new Error("Failed to read PDF file");
+        }
+
+        // Create a data URL from the base64 content
+        const dataUrl = `data:application/pdf;base64,${base64Content}`;
+        setPdfFile(dataUrl);
+      } catch (err) {
+        setError(err instanceof Error ? err.message : "Failed to load PDF file");
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    loadPDFFile();
+  }, [filePath]);
+
+  const onDocumentLoadSuccess = ({ numPages }: { numPages: number }) => {
+    setNumPages(numPages);
+  };
+
+  const onDocumentLoadError = (error: Error) => {
+    setError(`Failed to load PDF: ${error.message}`);
+  };
+
+  const zoomIn = () => {
+    setScale(prev => Math.min(3.0, prev + 0.25));
+  };
+
+  const zoomOut = () => {
+    setScale(prev => Math.max(0.5, prev - 0.25));
+  };
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center p-8">
+        <div className="flex items-center gap-3">
+          <FileText className="h-8 w-8 animate-pulse text-red-500" />
+          <span>Loading PDF...</span>
+        </div>
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="flex items-center justify-center p-8 text-red-500">
+        <div className="flex items-center gap-3">
+          <AlertCircle className="h-8 w-8" />
+          <span>{error}</span>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex flex-col h-full">
+      {/* Controls */}
+      <div className="flex items-center justify-between p-3 border-b bg-muted/30 flex-shrink-0">
+        <div className="flex items-center gap-2">
+          <FileText className="h-4 w-4 text-red-500" />
+          <span className="text-sm font-medium">PDF Viewer</span>
+        </div>
+        
+        <div className="flex items-center gap-2">
+          {/* Zoom controls */}
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={zoomOut}
+            disabled={scale <= 0.5}
+            className="h-7 w-7 p-0"
+          >
+            <ZoomOut className="h-3.5 w-3.5" />
+          </Button>
+          <Badge variant="outline" className="text-xs px-2 py-0.5">
+            {Math.round(scale * 100)}%
+          </Badge>
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={zoomIn}
+            disabled={scale >= 3.0}
+            className="h-7 w-7 p-0"
+          >
+            <ZoomIn className="h-3.5 w-3.5" />
+          </Button>
+
+          {numPages && (
+            <>
+              <div className="w-px h-4 bg-border mx-1" />
+              
+              {/* Page count display */}
+              <Badge variant="outline" className="text-xs px-2 py-0.5">
+                {numPages} {numPages === 1 ? 'page' : 'pages'}
+              </Badge>
+            </>
+          )}
+        </div>
+      </div>
+
+      {/* PDF Content */}
+      <div 
+        className="overflow-auto bg-gray-100 dark:bg-gray-900" 
+        style={{ height: '600px', maxHeight: '70vh' }}
+      >
+        <div className="flex flex-col items-center gap-4 p-4" style={{ minHeight: '100%' }}>
+          {pdfFile && (
+            <Document
+              file={pdfFile}
+              onLoadSuccess={onDocumentLoadSuccess}
+              onLoadError={onDocumentLoadError}
+              loading={
+                <div className="flex items-center gap-2 p-8">
+                  <FileText className="h-6 w-6 animate-pulse text-red-500" />
+                  <span>Loading PDF document...</span>
+                </div>
+              }
+              error={
+                <div className="flex items-center gap-2 p-8 text-red-500">
+                  <AlertCircle className="h-6 w-6" />
+                  <span>Error loading PDF document</span>
+                </div>
+              }
+            >
+              {/* Render all pages for continuous scrolling */}
+              <div className="flex flex-col items-center gap-4">
+                {numPages && Array.from(new Array(numPages), (_, index) => (
+                  <Page
+                    key={`page_${index + 1}`}
+                    pageNumber={index + 1}
+                    scale={scale}
+                    renderTextLayer={false}
+                    renderAnnotationLayer={false}
+                    className="shadow-lg"
+                  />
+                ))}
+              </div>
+            </Document>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -114,6 +114,7 @@ export interface API {
     is_binary: boolean;
     error: string | null;
   }>;
+  read_binary_file_as_base64(params: { path: string }): Promise<string>;
   read_file_content_with_options(params: {
     path: string;
     forceText: boolean;

--- a/frontend/src/lib/webApi.ts
+++ b/frontend/src/lib/webApi.ts
@@ -185,6 +185,11 @@ export const webApi: API = {
     return response.data;
   },
 
+  async read_binary_file_as_base64(params) {
+    const response = await apiClient.post<string>("/read-binary-file-as-base64", params);
+    return response.data;
+  },
+
   async get_detailed_conversation(params: { chatId: string }) {
     const encodedChatId = encodeURIComponent(params.chatId);
     const response = await apiClient.get<DetailedConversation>(

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -18,6 +18,12 @@ export default defineConfig({
   build: {
     target: "esnext",
     emptyOutDir: false,
+    rollupOptions: {
+      external: [],
+    },
+  },
+  optimizeDeps: {
+    include: ['pdfjs-dist'],
   },
   define: {
     // eslint-disable-next-line no-undef


### PR DESCRIPTION
- Add binary file reading capability with base64 encoding support across backend, server, and Tauri app layers

- Implement specialized viewers for PDF files using react-pdf with local worker configuration

- Create Excel/spreadsheet viewer supporting multiple formats (xlsx, xls, csv) with sheet navigation and tabular display

- Add image viewer with zoom, rotation, and download functionality for common image formats

- Enhance FileContentViewer to automatically detect file types and route to appropriate specialized viewers

- Update build process to copy PDF.js worker files and configure dependencies for new viewing capabilities