### PR TITLE
refactor(viewer): remove redundant file type handling for non-text files

### DIFF
--- a/frontend/src/components/common/FileContentViewer.tsx
+++ b/frontend/src/components/common/FileContentViewer.tsx
@@ -82,25 +82,6 @@ export function FileContentViewer({
       return;
     }
 
-    const fileType = getFileType(filePath);
-
-    // For specialized file types (excel, pdf, image), we don't need to load content
-    // The specialized viewers will handle their own loading
-    if (fileType !== "text") {
-      setFileContent({
-        path: filePath,
-        content: null,
-        size: 0,
-        modified: null,
-        encoding: "binary",
-        is_text: false,
-        is_binary: true,
-        error: null,
-      });
-      setLoading(false);
-      return;
-    }
-
     const loadFileContent = async () => {
       setLoading(true);
       setError(null);


### PR DESCRIPTION
- Remove duplicate file type checking logic that was bypassing content loading

- Simplify FileContentViewer by letting specialized viewers handle their own loading logic

- Eliminate unnecessary early return for binary files that prevented proper content handling