### PR TITLE
fix(viewer): improve image display with proper sizing and centering

### DIFF
--- a/frontend/src/components/common/ImageViewer.tsx
+++ b/frontend/src/components/common/ImageViewer.tsx
@@ -230,7 +230,7 @@ export function ImageViewer({ filePath }: ImageViewerProps) {
             <img
               src={imageData}
               alt={filePath.split("/").pop() || "Image"}
-              className="max-w-none shadow-lg"
+              className="max-w-full max-h-full object-contain shadow-lg"
               style={{
                 transform: `scale(${scale}) rotate(${rotation}deg)`,
                 transition: "transform 0.2s ease-in-out",


### PR DESCRIPTION
- Change max-width from 'none' to 'full' to prevent overflow

- Add max-height constraint to maintain viewport boundaries

- Apply object-contain to preserve aspect ratio while fitting container


Closes #109 