### PR TITLE
refactor(ui): simplify MCP permission interface and enhance option handling

### DIFF
--- a/frontend/src/components/mcp/McpPermissionCompact.tsx
+++ b/frontend/src/components/mcp/McpPermissionCompact.tsx
@@ -71,54 +71,22 @@ export function McpPermissionCompact({
         <span className="font-medium">{toolName}</span>
         <span className="text-muted-foreground">from {serverName}</span>
 
-        {/* Compact permission buttons in header */}
+        {/* Basic permission buttons in header - Allow and Reject only */}
         <div
           className="ml-auto flex items-center gap-1"
           onClick={(e) => e.stopPropagation()}
         >
-          {/* Always allow server (green) */}
-          {serverOptions
-            .filter((opt) => opt.kind === "allow_always")
-            .map((option) => (
-              <Button
-                key={option.optionId}
-                size="sm"
-                variant="default"
-                className={getButtonStyle(option)}
-                onClick={() => onPermissionResponse(option.optionId)}
-                title={option.name}
-              >
-                {getButtonIcon(option)}
-              </Button>
-            ))}
-
-          {/* Always allow tool (green) */}
-          {toolOptions
-            .filter((opt) => opt.kind === "allow_always")
-            .map((option) => (
-              <Button
-                key={option.optionId}
-                size="sm"
-                variant="default"
-                className={getButtonStyle(option)}
-                onClick={() => onPermissionResponse(option.optionId)}
-                title={option.name}
-              >
-                {getButtonIcon(option)}
-              </Button>
-            ))}
-
-          {/* Allow once (blue) */}
+          {/* Allow once (green) */}
           {allowOnceOptions.map((option) => (
             <Button
               key={option.optionId}
               size="sm"
               variant="default"
-              className={getButtonStyle(option)}
+              className="h-6 w-6 p-0 bg-green-600 hover:bg-green-700 text-white"
               onClick={() => onPermissionResponse(option.optionId)}
               title={option.name}
             >
-              {getButtonIcon(option)}
+              <Check className="h-3 w-3" />
             </Button>
           ))}
 
@@ -128,11 +96,11 @@ export function McpPermissionCompact({
               key={option.optionId}
               size="sm"
               variant="default"
-              className={getButtonStyle(option)}
+              className="h-6 w-6 p-0 bg-red-600 hover:bg-red-700 text-white"
               onClick={() => onPermissionResponse(option.optionId)}
               title={option.name}
             >
-              {getButtonIcon(option)}
+              <X className="h-3 w-3" />
             </Button>
           ))}
         </div>
@@ -159,7 +127,7 @@ export function McpPermissionCompact({
           <div className="space-y-1">
             {serverOptions.length > 0 && (
               <div className="flex items-center gap-2 text-xs">
-                <span className="text-green-700">🟢 Server-level:</span>
+                <span className="text-green-700">Server-level:</span>
                 {serverOptions.map((option) => (
                   <Button
                     key={option.optionId}
@@ -176,7 +144,7 @@ export function McpPermissionCompact({
 
             {toolOptions.length > 0 && (
               <div className="flex items-center gap-2 text-xs">
-                <span className="text-green-700">🔧 Tool-level:</span>
+                <span className="text-green-700">Tool-level:</span>
                 {toolOptions.map((option) => (
                   <Button
                     key={option.optionId}

--- a/frontend/src/components/mcp/McpPermissionCompact.tsx
+++ b/frontend/src/components/mcp/McpPermissionCompact.tsx
@@ -43,22 +43,6 @@ export function McpPermissionCompact({
     (opt) => opt.kind === "reject_once"
   );
 
-  const getButtonStyle = (option: McpPermissionOption) => {
-    if (option.kind === "allow_always")
-      return "h-6 w-6 p-0 bg-green-600 hover:bg-green-700 text-white";
-    if (option.kind === "allow_once")
-      return "h-6 w-6 p-0 bg-green-600 hover:bg-green-700 text-white";
-    if (option.kind === "reject_once")
-      return "h-6 w-6 p-0 bg-red-600 hover:bg-red-700 text-white";
-    return "h-6 w-6 p-0";
-  };
-
-  const getButtonIcon = (option: McpPermissionOption) => {
-    if (option.kind.includes("allow")) return <Check className="h-3 w-3" />;
-    if (option.kind.includes("reject")) return <X className="h-3 w-3" />;
-    return <Wrench className="h-3 w-3" />;
-  };
-
   return (
     <div className="mt-4">
       {/* Compact header matching other tool renderers */}

--- a/frontend/src/components/mcp/McpPermissionCompact.tsx
+++ b/frontend/src/components/mcp/McpPermissionCompact.tsx
@@ -1,7 +1,7 @@
 import { useState } from "react";
 import { ChevronRight, Wrench, Check, X } from "lucide-react";
 import { Button } from "../ui/button";
-import { McpPermissionRequest, McpPermissionOption } from "../../types";
+import { McpPermissionRequest } from "../../types";
 
 interface McpPermissionCompactProps {
   request: McpPermissionRequest;

--- a/frontend/src/hooks/useConversationEvents.ts
+++ b/frontend/src/hooks/useConversationEvents.ts
@@ -220,6 +220,19 @@ function convertAcpContentToLegacy(acpContent: AcpContent[]): LegacyResult {
   };
 }
 
+function getOptionKind(idx: number): "allow_once" | "allow_always" | "reject_once" | "reject_always" {
+  switch (idx) {
+    case 0:
+      return "allow_once";
+    case 1:
+      return "allow_always";
+    case 2:
+      return "reject_once";
+    default:
+      return "reject_always";
+  }
+}
+
 export const useConversationEvents = (
   setCliIOLogs: React.Dispatch<React.SetStateAction<CliIO[]>>,
   setConfirmationRequests: React.Dispatch<
@@ -611,17 +624,7 @@ export const useConversationEvents = (
                     ? (request.options as string[]).map((opt, idx) => ({
                         optionId: `option_${idx}`,
                         name: opt,
-                        kind: (idx < 2
-                          ? idx === 0
-                            ? "allow_once"
-                            : "allow_always"
-                          : idx === 2
-                            ? "reject_once"
-                            : "reject_always") as
-                          | "allow_once"
-                          | "allow_always"
-                          | "reject_once"
-                          | "reject_always",
+                        kind: getOptionKind(idx),
                       }))
                     : (request.options as {
                         optionId: string;
@@ -772,6 +775,34 @@ export const useConversationEvents = (
                 })
               ),
               inputJsonRpc: window.pendingToolCallInput,
+              // Include ACP permission options for enhanced approval flows
+              options: Array.isArray(request.options)
+                ? typeof request.options[0] === "string"
+                  ? (request.options as string[]).map((opt, idx) => ({
+                      optionId: `option_${idx}`,
+                      name: opt,
+                      kind: (idx < 2
+                        ? idx === 0
+                          ? "allow_once"
+                          : "allow_always"
+                        : idx === 2
+                          ? "reject_once"
+                          : "reject_always") as
+                        | "allow_once"
+                        | "allow_always"
+                        | "reject_once"
+                        | "reject_always",
+                    }))
+                  : (request.options as {
+                      optionId: string;
+                      name: string;
+                      kind:
+                        | "allow_once"
+                        | "allow_always"
+                        | "reject_once"
+                        | "reject_always";
+                    }[])
+                : [],
             };
 
             setConfirmationRequests((prev) => {

--- a/frontend/src/hooks/useConversationEvents.ts
+++ b/frontend/src/hooks/useConversationEvents.ts
@@ -220,7 +220,9 @@ function convertAcpContentToLegacy(acpContent: AcpContent[]): LegacyResult {
   };
 }
 
-function getOptionKind(idx: number): "allow_once" | "allow_always" | "reject_once" | "reject_always" {
+function getOptionKind(
+  idx: number
+): "allow_once" | "allow_always" | "reject_once" | "reject_always" {
   switch (idx) {
     case 0:
       return "allow_once";


### PR DESCRIPTION
- Remove complex server-level and tool-level permission buttons from compact header

- Streamline to basic Allow/Reject buttons with consistent green/red styling

- Extract option kind mapping logic into reusable getOptionKind function

- Add comprehensive ACP permission options to tool call confirmation requests

- Remove emoji indicators from permission labels for cleaner UI


Closes #105 