### PR TITLE
feat(ui): move settings from sidebar to dedicated dialog

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -169,11 +169,16 @@ function RootLayoutContent() {
   // Open Settings dialog when a global event is dispatched
   useEffect(() => {
     const handler = () => setIsSettingsOpen(true);
-    window.addEventListener("app:open-settings", handler as EventListener);
+    // Type guard for addEventListener/removeEventListener signature without using any
+    type WindowEventHandler = (this: Window, ev: Event) => unknown;
+    window.addEventListener(
+      "app:open-settings",
+      handler as unknown as WindowEventHandler
+    );
     return () =>
       window.removeEventListener(
         "app:open-settings",
-        handler as EventListener
+        handler as unknown as WindowEventHandler
       );
   }, []);
 

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -37,6 +37,7 @@ import { CliIO, Conversation, Message } from "./types";
 import "./index.css";
 import { platform } from "@tauri-apps/plugin-os";
 import { AboutDialog } from "./components/common/AboutDialog";
+import { SettingsDialog } from "./components/common/SettingsDialog";
 
 function RootLayoutContent() {
   const { progress, startListeningForSession } = useSessionProgress();
@@ -47,6 +48,7 @@ function RootLayoutContent() {
   const messagesContainerRef = useRef<HTMLDivElement>(null);
   const [sidebarOpen, setSidebarOpen] = useState(true);
   const [directoryPanelOpen, setDirectoryPanelOpen] = useState(false);
+  const [isSettingsOpen, setIsSettingsOpen] = useState(false);
   const [workingDirectory, setWorkingDirectory] = useState<string>(".");
   const [isContinuingConversation, setIsContinuingConversation] =
     useState(false);
@@ -163,6 +165,17 @@ function RootLayoutContent() {
       setWorkingDirectory(currentConversationWithStatus.workingDirectory);
     }
   }, [currentConversationWithStatus]);
+
+  // Open Settings dialog when a global event is dispatched
+  useEffect(() => {
+    const handler = () => setIsSettingsOpen(true);
+    window.addEventListener("app:open-settings", handler as EventListener);
+    return () =>
+      window.removeEventListener(
+        "app:open-settings",
+        handler as EventListener
+      );
+  }, []);
 
   // Progress listener started in startNewConversation
 
@@ -382,6 +395,7 @@ function RootLayoutContent() {
             isDirectoryPanelOpen={directoryPanelOpen}
             hasActiveConversation={!!activeConversation}
             onReturnToDashboard={() => setActiveConversation(null)}
+            onOpenSettings={() => setIsSettingsOpen(true)}
           />
           <div className="flex flex-col h-full">
             <Outlet context={{ workingDirectory }} />
@@ -425,6 +439,12 @@ function RootLayoutContent() {
           )}
         </SidebarInset>
       </AppSidebar>
+      {/* Settings Dialog */}
+      <SettingsDialog
+        open={isSettingsOpen}
+        onOpenChange={setIsSettingsOpen}
+        onModelChange={handleModelChange}
+      />
     </ConversationContext.Provider>
   );
 }

--- a/frontend/src/components/common/SettingsDialog.tsx
+++ b/frontend/src/components/common/SettingsDialog.tsx
@@ -1,0 +1,360 @@
+import React from "react";
+import { useTranslation } from "react-i18next";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+} from "@/components/ui/dialog";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Input } from "@/components/ui/input";
+import { Checkbox } from "@/components/ui/checkbox";
+import { AlertTriangle } from "lucide-react";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
+import { useBackend, useBackendConfig } from "@/contexts/BackendContext";
+import { getBackendText } from "@/utils/backendText";
+import { GeminiAuthMethod } from "@/types/backend";
+
+interface SettingsDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onModelChange?: (model: string) => void;
+}
+
+export const SettingsDialog: React.FC<SettingsDialogProps> = ({
+  open,
+  onOpenChange,
+  onModelChange,
+}) => {
+  const { t, i18n } = useTranslation();
+  const { selectedBackend, switchBackend } = useBackend();
+  const { config: qwenConfig, updateConfig: updateQwenConfig } =
+    useBackendConfig("qwen");
+  const { config: geminiConfig, updateConfig: updateGeminiConfig } =
+    useBackendConfig("gemini");
+
+  const backendText = getBackendText(selectedBackend);
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-2xl max-h-[85vh] overflow-auto">
+        <DialogHeader>
+          <DialogTitle>{t("advancedSettings", { defaultValue: "Settings" })}</DialogTitle>
+        </DialogHeader>
+
+        <div className="space-y-6 py-2">
+          {/* Language Selector */}
+          <div>
+            <label className="text-sm font-medium text-gray-700 dark:text-gray-300 mb-2 block">
+              {t("conversations.language")}
+            </label>
+            <Select
+              value={i18n.language}
+              onValueChange={(value) => {
+                i18n.changeLanguage(value);
+              }}
+            >
+              <SelectTrigger className="w-full">
+                <SelectValue placeholder={t("conversations.selectLanguage")} />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="en">English</SelectItem>
+                <SelectItem value="zh-CN">简体中文</SelectItem>
+                <SelectItem value="zh-TW">繁體中文</SelectItem>
+              </SelectContent>
+            </Select>
+          </div>
+
+          {/* Backend Selector */}
+          <div>
+            <label className="text-sm font-medium text-gray-700 dark:text-gray-300 mb-2 block">
+              {t("conversations.backend")}
+            </label>
+            <Select
+              value={selectedBackend}
+              onValueChange={(value) => {
+                switchBackend(value as "gemini" | "qwen");
+                // No-op for model change here; model is handled below
+              }}
+            >
+              <SelectTrigger className="w-full">
+                <SelectValue placeholder={t("conversations.selectBackend")} />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="gemini">{t("backend.geminiCli")}</SelectItem>
+                <SelectItem value="qwen">{t("backend.qwenCode")}</SelectItem>
+              </SelectContent>
+            </Select>
+          </div>
+
+          {/* Qwen Code Configuration */}
+          {selectedBackend === "qwen" && (
+            <div className="space-y-3 p-3 border border-gray-200 dark:border-gray-700 rounded-md">
+              <h4 className="text-sm font-medium text-gray-700 dark:text-gray-300">
+                {t("backend.qwenConfiguration")}
+              </h4>
+
+              {/* OAuth Checkbox */}
+              <div className="flex items-center space-x-2">
+                <Checkbox
+                  id="oauth-checkbox"
+                  checked={qwenConfig.useOAuth}
+                  onCheckedChange={(checked) =>
+                    updateQwenConfig({ useOAuth: checked === true })
+                  }
+                />
+                <label
+                  htmlFor="oauth-checkbox"
+                  className="text-sm font-medium text-gray-700 dark:text-gray-300 cursor-pointer"
+                >
+                  {t("conversations.oauth")}
+                </label>
+              </div>
+
+              {!qwenConfig.useOAuth && (
+                <>
+                  <div>
+                    <label className="text-xs font-medium text-gray-600 dark:text-gray-400 mb-1 block">
+                      {t("conversations.apiKey")}
+                    </label>
+                    <Input
+                      type="password"
+                      value={qwenConfig.apiKey}
+                      onChange={(e) =>
+                        updateQwenConfig({
+                          apiKey: e.target.value,
+                        })
+                      }
+                      placeholder={t("conversations.apiKey")}
+                    />
+                  </div>
+
+                  <div>
+                    <label className="text-xs font-medium text-gray-600 dark:text-gray-400 mb-1 block">
+                      {t("conversations.baseUrl")}
+                    </label>
+                    <Input
+                      type="text"
+                      value={qwenConfig.baseUrl}
+                      onChange={(e) =>
+                        updateQwenConfig({
+                          baseUrl: e.target.value,
+                        })
+                      }
+                      placeholder="https://openrouter.ai/api/v1"
+                    />
+                  </div>
+
+                  <div>
+                    <label className="text-xs font-medium text-gray-600 dark:text-gray-400 mb-1 block">
+                      {t("conversations.model")}
+                    </label>
+                    <Input
+                      type="text"
+                      value={qwenConfig.model}
+                      onChange={(e) => {
+                        const value = e.target.value;
+                        updateQwenConfig({ model: value });
+                        onModelChange?.(value || "qwen/qwen3-coder:free");
+                      }}
+                      placeholder="qwen/qwen3-coder:free"
+                    />
+                  </div>
+                </>
+              )}
+            </div>
+          )}
+
+          {/* Gemini Configuration */}
+          {selectedBackend === "gemini" && (
+            <div className="space-y-3">
+              <div>
+                <label className="text-sm font-medium text-gray-700 dark:text-gray-300 mb-2 block">
+                  {t("conversations.model")}
+                </label>
+                <Select
+                  value={geminiConfig.defaultModel || "gemini-2.5-flash"}
+                  onValueChange={(value) => {
+                    updateGeminiConfig({ defaultModel: value });
+                    onModelChange?.(value);
+                  }}
+                >
+                  <SelectTrigger className="w-full">
+                    <SelectValue placeholder={t("conversations.selectModel")} />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="gemini-2.5-pro">
+                      {t("backend.geminiModels.pro")}
+                    </SelectItem>
+                    <SelectItem value="gemini-2.5-flash">
+                      {t("backend.geminiModels.flash")}
+                    </SelectItem>
+                    <SelectItem value="gemini-2.5-flash-lite">
+                      <div className="flex items-center gap-2">
+                        <span>{t("backend.geminiModels.flashLite")}</span>
+                        <Tooltip>
+                          <TooltipTrigger asChild>
+                            <AlertTriangle className="h-4 w-4 text-yellow-500" />
+                          </TooltipTrigger>
+                          <TooltipContent>
+                            <p>{t("backend.stillWaiting")}</p>
+                          </TooltipContent>
+                        </Tooltip>
+                      </div>
+                    </SelectItem>
+                  </SelectContent>
+                </Select>
+              </div>
+
+              {/* Gemini Authentication Configuration */}
+              <div className="space-y-3 mt-2">
+                {/* Authentication Method Selector */}
+                <div>
+                  <label className="text-sm font-medium text-gray-700 dark:text-gray-300 mb-2 block">
+                    {t("conversations.authMethod")}
+                  </label>
+                  <Select
+                    value={geminiConfig.authMethod}
+                    onValueChange={(value) =>
+                      updateGeminiConfig({
+                        authMethod: value as GeminiAuthMethod,
+                      })
+                    }
+                  >
+                    <SelectTrigger className="w-full">
+                      <SelectValue placeholder={t("conversations.selectAuthMethod")} />
+                    </SelectTrigger>
+                    <SelectContent>
+                      <SelectItem value="oauth-personal">
+                        <div className="flex flex-col">
+                          <span>{t("backend.googleOAuth")}</span>
+                        </div>
+                      </SelectItem>
+                      <SelectItem value="gemini-api-key">
+                        <div className="flex flex-col">
+                          <span>{t("backend.apiKey")}</span>
+                        </div>
+                      </SelectItem>
+                      <SelectItem value="vertex-ai">
+                        <div className="flex flex-col">
+                          <span>{t("backend.vertexAi")}</span>
+                        </div>
+                      </SelectItem>
+                      <SelectItem value="cloud-shell">
+                        <div className="flex flex-col">
+                          <span>{t("backend.cloudShell")}</span>
+                        </div>
+                      </SelectItem>
+                    </SelectContent>
+                  </Select>
+                </div>
+
+                {/* API Key input - only show for API Key auth */}
+                {geminiConfig.authMethod === "gemini-api-key" && (
+                  <div>
+                    <label className="text-sm font-medium text-gray-700 dark:text-gray-300 mb-2 block">
+                      {t("conversations.apiKey")}
+                    </label>
+                    <Input
+                      type="password"
+                      value={geminiConfig.apiKey || ""}
+                      onChange={(e) =>
+                        updateGeminiConfig({ apiKey: e.target.value })
+                      }
+                      placeholder={t("backend.enterApiKey")}
+                    />
+                    <p className="text-xs text-gray-500 dark:text-gray-400 mt-1">
+                      {t("conversations.getApiKeyFrom")} {" "}
+                      <a
+                        href="https://aistudio.google.com/apikey"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="text-blue-500 hover:underline"
+                      >
+                        {t("backend.googleAiStudio")}
+                      </a>
+                    </p>
+                  </div>
+                )}
+
+                {/* Vertex AI configuration - only show for Vertex AI auth */}
+                {geminiConfig.authMethod === "vertex-ai" && (
+                  <>
+                    <div>
+                      <label className="text-sm font-medium text-gray-700 dark:text-gray-300 mb-2 block">
+                        {t("conversations.gcpProjectId")}
+                      </label>
+                      <Input
+                        type="text"
+                        value={geminiConfig.vertexProject || ""}
+                        onChange={(e) =>
+                          updateGeminiConfig({
+                            vertexProject: e.target.value,
+                          })
+                        }
+                        placeholder={t("backend.enterProjectId")}
+                      />
+                    </div>
+                    <div>
+                      <label className="text-sm font-medium text-gray-700 dark:text-gray-300 mb-2 block">
+                        {t("conversations.locationRegion")}
+                      </label>
+                      <Input
+                        type="text"
+                        value={geminiConfig.vertexLocation || ""}
+                        onChange={(e) =>
+                          updateGeminiConfig({
+                            vertexLocation: e.target.value,
+                          })
+                        }
+                        placeholder={t("backend.enterLocation")}
+                      />
+                    </div>
+                  </>
+                )}
+
+                {/* OAuth information */}
+                {geminiConfig.authMethod === "oauth-personal" && (
+                  <p className="text-xs text-gray-500 dark:text-gray-400">
+                    {t("conversations.oauthLimits")}
+                  </p>
+                )}
+
+                {/* Cloud Shell information */}
+                {geminiConfig.authMethod === "cloud-shell" && (
+                  <p className="text-sm text-gray-500 dark:text-gray-400">
+                    {t("conversations.cloudShellInfo")}
+                  </p>
+                )}
+
+                {/* YOLO Mode Checkbox */}
+                <div className="flex items-center space-x-2">
+                  <Checkbox
+                    id="yolo-checkbox"
+                    checked={geminiConfig.yolo || false}
+                    onCheckedChange={(checked) => {
+                      updateGeminiConfig({ yolo: checked === true });
+                    }}
+                  />
+                  <label
+                    htmlFor="yolo-checkbox"
+                    className="text-sm font-medium text-gray-700 dark:text-gray-300 cursor-pointer"
+                  >
+                    {t("conversations.yoloMode")}
+                  </label>
+                </div>
+              </div>
+            </div>
+          )}
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+};

--- a/frontend/src/components/common/SettingsDialog.tsx
+++ b/frontend/src/components/common/SettingsDialog.tsx
@@ -5,7 +5,6 @@ import {
   DialogContent,
   DialogHeader,
   DialogTitle,
-  DialogDescription,
 } from "@/components/ui/dialog";
 import {
   Select,
@@ -17,9 +16,12 @@ import {
 import { Input } from "@/components/ui/input";
 import { Checkbox } from "@/components/ui/checkbox";
 import { AlertTriangle } from "lucide-react";
-import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
 import { useBackend, useBackendConfig } from "@/contexts/BackendContext";
-import { getBackendText } from "@/utils/backendText";
 import { GeminiAuthMethod } from "@/types/backend";
 
 interface SettingsDialogProps {
@@ -40,13 +42,15 @@ export const SettingsDialog: React.FC<SettingsDialogProps> = ({
   const { config: geminiConfig, updateConfig: updateGeminiConfig } =
     useBackendConfig("gemini");
 
-  const backendText = getBackendText(selectedBackend);
+  // Derive translations directly where needed; remove unused variable to satisfy TS
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent className="sm:max-w-2xl max-h-[85vh] overflow-auto">
         <DialogHeader>
-          <DialogTitle>{t("advancedSettings", { defaultValue: "Settings" })}</DialogTitle>
+          <DialogTitle>
+            {t("advancedSettings", { defaultValue: "Settings" })}
+          </DialogTitle>
         </DialogHeader>
 
         <div className="space-y-6 py-2">
@@ -229,7 +233,9 @@ export const SettingsDialog: React.FC<SettingsDialogProps> = ({
                     }
                   >
                     <SelectTrigger className="w-full">
-                      <SelectValue placeholder={t("conversations.selectAuthMethod")} />
+                      <SelectValue
+                        placeholder={t("conversations.selectAuthMethod")}
+                      />
                     </SelectTrigger>
                     <SelectContent>
                       <SelectItem value="oauth-personal">
@@ -271,7 +277,7 @@ export const SettingsDialog: React.FC<SettingsDialogProps> = ({
                       placeholder={t("backend.enterApiKey")}
                     />
                     <p className="text-xs text-gray-500 dark:text-gray-400 mt-1">
-                      {t("conversations.getApiKeyFrom")} {" "}
+                      {t("conversations.getApiKeyFrom")}{" "}
                       <a
                         href="https://aistudio.google.com/apikey"
                         target="_blank"

--- a/frontend/src/components/conversation/ConversationList.tsx
+++ b/frontend/src/components/conversation/ConversationList.tsx
@@ -185,4 +185,3 @@ export function ConversationList({
     </div>
   );
 }
-

--- a/frontend/src/components/layout/AppHeader.tsx
+++ b/frontend/src/components/layout/AppHeader.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { useTranslation } from "react-i18next";
-import { FolderTree } from "lucide-react";
+import { FolderTree, Settings as SettingsIcon } from "lucide-react";
 import { SmartLogo } from "../branding/SmartLogo";
 import { DesktopText } from "../branding/DesktopText";
 import { PiebaldLogo } from "../branding/PiebaldLogo";
@@ -12,6 +12,7 @@ interface AppHeaderProps {
   isDirectoryPanelOpen?: boolean;
   hasActiveConversation?: boolean;
   onReturnToDashboard?: () => void;
+  onOpenSettings?: () => void;
 }
 
 export const AppHeader: React.FC<AppHeaderProps> = ({
@@ -19,6 +20,7 @@ export const AppHeader: React.FC<AppHeaderProps> = ({
   isDirectoryPanelOpen = false,
   hasActiveConversation = false,
   onReturnToDashboard,
+  onOpenSettings,
 }) => {
   const { t } = useTranslation();
 
@@ -61,8 +63,18 @@ export const AppHeader: React.FC<AppHeaderProps> = ({
           {/* Center section - Empty spacer */}
           <div className="flex-1"></div>
 
-          {/* Right section - Directory Toggle + Piebald branding */}
+          {/* Right section - Settings + Directory Toggle + Piebald branding */}
           <div className="flex flex-1 items-center justify-end gap-4">
+            {onOpenSettings && (
+              <Button
+                variant="ghost"
+                size="icon"
+                onClick={onOpenSettings}
+                title={t("settings.open", { defaultValue: "Settings" })}
+              >
+                <SettingsIcon className="h-4 w-4" />
+              </Button>
+            )}
             {onDirectoryPanelToggle && hasActiveConversation && (
               <Button
                 variant="ghost"

--- a/frontend/src/components/layout/AppSidebar.tsx
+++ b/frontend/src/components/layout/AppSidebar.tsx
@@ -3,9 +3,12 @@ import { ConversationList } from "../conversation/ConversationList";
 import {
   Sidebar,
   SidebarContent,
+  SidebarFooter,
   SidebarProvider,
   SidebarTrigger,
 } from "../ui/sidebar";
+import { Settings as SettingsIcon } from "lucide-react";
+import { useTranslation } from "react-i18next";
 import type { Conversation, ProcessStatus } from "../../types";
 
 interface AppSidebarProps {
@@ -33,6 +36,7 @@ export function AppSidebar({
   onOpenChange,
   children,
 }: AppSidebarProps) {
+  const { t } = useTranslation();
   return (
     <SidebarProvider
       defaultOpen={true}
@@ -52,6 +56,16 @@ export function AppSidebar({
             onRemoveConversation={onRemoveConversation}
           />
         </SidebarContent>
+        <SidebarFooter className="mt-auto p-2 border-t border-sidebar-border">
+          <button
+            type="button"
+            onClick={() => window.dispatchEvent(new Event("app:open-settings"))}
+            className="w-full text-left text-sm text-muted-foreground hover:text-foreground flex items-center gap-2 px-2 py-2 rounded-md hover:bg-sidebar-accent"
+          >
+            <SettingsIcon className="h-4 w-4" />
+            {t("dashboard.settingsLink", { defaultValue: "Settings" })}
+          </button>
+        </SidebarFooter>
       </Sidebar>
       {children}
     </SidebarProvider>

--- a/frontend/src/components/layout/CustomTitleBar.tsx
+++ b/frontend/src/components/layout/CustomTitleBar.tsx
@@ -28,6 +28,7 @@ import {
   RotateCcw,
   Info,
   ChevronDown,
+  Settings as SettingsIcon,
 } from "lucide-react";
 import { AboutDialog } from "@/components/common/AboutDialog";
 
@@ -282,6 +283,18 @@ export const CustomTitleBar: React.FC<CustomTitleBarProps> = ({
                 </div>
                 <span className="text-xs text-muted-foreground">
                   {menuShortcuts.goMcpServers?.display}
+                </span>
+              </DropdownMenuItem>
+              <DropdownMenuItem
+                onClick={handlers.openSettings}
+                className="flex items-center justify-between text-xs"
+              >
+                <div className="flex items-center gap-2">
+                  <SettingsIcon size={14} />
+                  {labels.settings}
+                </div>
+                <span className="text-xs text-muted-foreground">
+                  {menuShortcuts.openSettings?.display}
                 </span>
               </DropdownMenuItem>
             </DropdownMenuContent>

--- a/frontend/src/hooks/useTauriMenu.ts
+++ b/frontend/src/hooks/useTauriMenu.ts
@@ -51,6 +51,12 @@ export const useTauriMenu = () => {
               accelerator: currentPlatform === "macos" ? "Cmd+M" : "Ctrl+M",
               action: handlers.goMcpServers,
             }),
+            await MenuItem.new({
+              id: "settings",
+              text: labels.settings,
+              accelerator: currentPlatform === "macos" ? "Cmd+," : "Ctrl+,",
+              action: handlers.openSettings,
+            }),
           ],
         });
 
@@ -91,6 +97,12 @@ export const useTauriMenu = () => {
                 text: t("titleBar.about", { name: "Gemini Desktop" }),
                 action: handlers.showAbout,
               }),
+              await MenuItem.new({
+                id: "settings",
+                text: labels.settings,
+                accelerator: "Cmd+,",
+                action: handlers.openSettings,
+              }),
               await PredefinedMenuItem.new({
                 item: "Separator",
               }),
@@ -130,6 +142,12 @@ export const useTauriMenu = () => {
                 text: labels.mcpServers,
                 accelerator: "Ctrl+M",
                 action: handlers.goMcpServers,
+              }),
+              await MenuItem.new({
+                id: "settings",
+                text: labels.settings,
+                accelerator: "Ctrl+,",
+                action: handlers.openSettings,
               }),
               await PredefinedMenuItem.new({
                 item: "Separator",

--- a/frontend/src/pages/HomeDashboard.tsx
+++ b/frontend/src/pages/HomeDashboard.tsx
@@ -23,7 +23,7 @@ import {
   CardTitle,
   CardDescription,
 } from "../components/ui/card";
-import { Info, UserRound, FolderKanban, Settings as SettingsIcon } from "lucide-react";
+import { Info, UserRound, FolderKanban } from "lucide-react";
 import { ModelContextProtocol } from "../components/common/ModelContextProtocol";
 import { getBackendText } from "../utils/backendText";
 import { useBackend } from "../contexts/BackendContext";

--- a/frontend/src/pages/HomeDashboard.tsx
+++ b/frontend/src/pages/HomeDashboard.tsx
@@ -23,7 +23,7 @@ import {
   CardTitle,
   CardDescription,
 } from "../components/ui/card";
-import { Info, UserRound, FolderKanban } from "lucide-react";
+import { Info, UserRound, FolderKanban, Settings as SettingsIcon } from "lucide-react";
 import { ModelContextProtocol } from "../components/common/ModelContextProtocol";
 import { getBackendText } from "../utils/backendText";
 import { useBackend } from "../contexts/BackendContext";
@@ -267,6 +267,8 @@ ${part.thinking}`;
               </CardHeader>
             </Card>
           </div>
+
+          {/* Settings link moved to sidebar footer */}
         </div>
       )}
     </>

--- a/frontend/src/utils/menuConfig.ts
+++ b/frontend/src/utils/menuConfig.ts
@@ -58,7 +58,11 @@ export const getMenuShortcuts = (): Record<
       [modifierKey]: true,
       display: `${displayModifier}M`,
     },
-    openSettings: { key: ",", [modifierKey]: true, display: `${displayModifier},` },
+    openSettings: {
+      key: ",",
+      [modifierKey]: true,
+      display: `${displayModifier},`,
+    },
     toggleTheme: undefined, // No accelerator in Linux menu
     refresh: { key: "r", [modifierKey]: true, display: `${displayModifier}R` },
     showAbout: undefined, // No accelerator in Linux menu

--- a/frontend/src/utils/menuConfig.ts
+++ b/frontend/src/utils/menuConfig.ts
@@ -7,6 +7,7 @@ export interface MenuHandler {
   goHome: () => void;
   goProjects: () => void;
   goMcpServers: () => void;
+  openSettings: () => void;
   toggleTheme: () => void;
   refresh: () => void;
   showAbout: () => void;
@@ -57,6 +58,7 @@ export const getMenuShortcuts = (): Record<
       [modifierKey]: true,
       display: `${displayModifier}M`,
     },
+    openSettings: { key: ",", [modifierKey]: true, display: `${displayModifier},` },
     toggleTheme: undefined, // No accelerator in Linux menu
     refresh: { key: "r", [modifierKey]: true, display: `${displayModifier}R` },
     showAbout: undefined, // No accelerator in Linux menu
@@ -71,6 +73,15 @@ export const createMenuHandlers = (
   goHome: () => navigate("/"),
   goProjects: () => navigate("/projects"),
   goMcpServers: () => navigate("/mcp"),
+  openSettings: () => {
+    // Broadcast an app-wide event to open the Settings dialog
+    try {
+      window.dispatchEvent(new CustomEvent("app:open-settings"));
+    } catch {
+      // Fallback for environments without CustomEvent
+      window.dispatchEvent(new Event("app:open-settings"));
+    }
+  },
   toggleTheme: () => {
     const html = document.documentElement;
     html.classList.toggle("dark");
@@ -94,6 +105,7 @@ export const getMenuLabels = (
     file: t("titleBar.file"),
     view: t("titleBar.view"),
     help: t("titleBar.help"),
+    settings: t("titleBar.settings", { defaultValue: "Settings…" }),
     home: t("titleBar.home"),
     projects: t("titleBar.projects"),
     mcpServers: t("titleBar.mcpServers"),


### PR DESCRIPTION
- Extract all configuration options from ConversationList sidebar into new SettingsDialog component

- Add settings button to AppHeader and sidebar footer for easy access

- Implement global event system for opening settings dialog from menu items and keyboard shortcuts

- Add settings menu item to Tauri native menus with Cmd/Ctrl+, shortcut

- Simplify ConversationList to focus on search and conversation management only

- Maintain all existing configuration functionality while improving UX with dedicated settings interface