### PR TITLE
fix(ui): restore right-docked directory panel

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -432,7 +432,9 @@ function RootLayoutContent() {
                     handleInputChange={handleInputChange}
                     handleSendMessage={handleSendMessage}
                     workingDirectory={workingDirectory}
-                    isConversationActive={currentConversationWithStatus.isActive}
+                    isConversationActive={
+                      currentConversationWithStatus.isActive
+                    }
                     onContinueConversation={() =>
                       handleContinueConversation(currentConversationWithStatus)
                     }

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -395,53 +395,69 @@ function RootLayoutContent() {
         onOpenChange={setSidebarOpen}
       >
         <SidebarInset>
-          <AppHeader
-            onDirectoryPanelToggle={toggleDirectoryPanel}
-            isDirectoryPanelOpen={directoryPanelOpen}
-            hasActiveConversation={!!activeConversation}
-            onReturnToDashboard={() => setActiveConversation(null)}
-            onOpenSettings={() => setIsSettingsOpen(true)}
-          />
-          <div className="flex flex-col h-full">
-            <Outlet context={{ workingDirectory }} />
-            {currentConversationWithStatus && (
-              <>
-                {console.log(
-                  "📝 [App] Rendering MessageInputBar with workingDirectory:",
-                  workingDirectory
-                )}
-                <MessageInputBar
-                  ref={messageInputBarRef}
-                  input={input}
-                  isCliInstalled={isCliInstalled}
-                  cliIOLogs={cliIOLogs}
-                  handleInputChange={handleInputChange}
-                  handleSendMessage={handleSendMessage}
+          {/* Grid layout: header spans all columns; content + optional right panel */}
+          <div
+            className="grid h-full"
+            style={{
+              gridTemplateRows: "auto 1fr",
+              gridTemplateColumns:
+                directoryPanelOpen && activeConversation ? "1fr 20rem" : "1fr",
+            }}
+          >
+            {/* Header */}
+            <div className="row-start-1 col-span-full">
+              <AppHeader
+                onDirectoryPanelToggle={toggleDirectoryPanel}
+                isDirectoryPanelOpen={directoryPanelOpen}
+                hasActiveConversation={!!activeConversation}
+                onReturnToDashboard={() => setActiveConversation(null)}
+                onOpenSettings={() => setIsSettingsOpen(true)}
+              />
+            </div>
+
+            {/* Main content column */}
+            <div className="row-start-2 col-start-1 flex flex-col min-w-0 min-h-0">
+              <Outlet context={{ workingDirectory }} />
+              {currentConversationWithStatus && (
+                <>
+                  {console.log(
+                    "📝 [App] Rendering MessageInputBar with workingDirectory:",
+                    workingDirectory
+                  )}
+                  <MessageInputBar
+                    ref={messageInputBarRef}
+                    input={input}
+                    isCliInstalled={isCliInstalled}
+                    cliIOLogs={cliIOLogs}
+                    handleInputChange={handleInputChange}
+                    handleSendMessage={handleSendMessage}
+                    workingDirectory={workingDirectory}
+                    isConversationActive={currentConversationWithStatus.isActive}
+                    onContinueConversation={() =>
+                      handleContinueConversation(currentConversationWithStatus)
+                    }
+                    isContinuingConversation={isContinuingConversation}
+                    isNew={currentConversationWithStatus.isNew}
+                    isStreaming={currentConversationWithStatus.isStreaming}
+                  />
+                </>
+              )}
+            </div>
+
+            {/* Right directory panel */}
+            {directoryPanelOpen && activeConversation && (
+              <div className="row-start-2 col-start-2 border-l min-h-0">
+                <DirectoryPanel
                   workingDirectory={workingDirectory}
-                  isConversationActive={currentConversationWithStatus.isActive}
-                  onContinueConversation={() =>
-                    handleContinueConversation(currentConversationWithStatus)
-                  }
-                  isContinuingConversation={isContinuingConversation}
-                  isNew={currentConversationWithStatus.isNew}
-                  isStreaming={currentConversationWithStatus.isStreaming}
+                  onDirectoryChange={(path) => {
+                    console.log("📁 [App] Directory changed to:", path);
+                  }}
+                  onMentionInsert={handleMentionInsert}
+                  className="w-[20rem] h-full"
                 />
-              </>
+              </div>
             )}
           </div>
-
-          {/* Directory Panel */}
-          {directoryPanelOpen && activeConversation && (
-            <DirectoryPanel
-              workingDirectory={workingDirectory}
-              onDirectoryChange={(path) => {
-                console.log("📁 [App] Directory changed to:", path);
-                // Optionally update working directory or perform other actions
-              }}
-              onMentionInsert={handleMentionInsert}
-              className="w-80 flex-shrink-0"
-            />
-          )}
         </SidebarInset>
       </AppSidebar>
       {/* Settings Dialog */}

--- a/frontend/src/components/conversation/MessageInputBar.tsx
+++ b/frontend/src/components/conversation/MessageInputBar.tsx
@@ -99,7 +99,7 @@ export const MessageInputBar = forwardRef<
         return null;
       }
       return (
-        <div className="sticky bottom-0 bg-white dark:bg-neutral-900 flex items-center p-6">
+        <div className="mt-auto border-t bg-white dark:bg-neutral-900 flex items-center p-6">
           <Button
             className="w-full"
             onClick={onContinueConversation}
@@ -122,7 +122,7 @@ export const MessageInputBar = forwardRef<
     }
 
     return (
-      <div className="sticky bottom-0 bg-white dark:bg-neutral-900 flex items-center">
+      <div className="mt-auto border-t bg-white dark:bg-neutral-900 flex items-center">
         <div className="px-6 pb-3 pt-2 w-full">
           {/* Message timer - positioned above input when active */}
           {isTimerActive && (


### PR DESCRIPTION
- Regression introduced in b28e53d where the directory panel dropped below the content due to a sticky input bar.
- Use a two-column grid under SidebarInset (header spans full width; content left, panel right).
- Make MessageInputBar non-sticky so it doesn’t affect sibling layout.

Fixes #124 