### PR TITLE
fix(ui): show backend progress messages; fix listener lifecycle; seed initial progress

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -41,7 +41,7 @@ import { AboutDialog } from "./components/common/AboutDialog";
 import { SettingsDialog } from "./components/common/SettingsDialog";
 
 function RootLayoutContent() {
-  const { progress, startListeningForSession } = useSessionProgress();
+  const { progress, startListeningForSession, seedProgress } = useSessionProgress();
 
   const [selectedModel, setSelectedModel] =
     useState<string>("gemini-2.5-flash");
@@ -296,6 +296,18 @@ function RootLayoutContent() {
                 ? geminiConfig.vertexLocation
                 : undefined,
           };
+        }
+
+        // Optimistically seed initial progress so the UI shows immediately
+        try {
+          const backendName = getBackendText(selectedBackend).name;
+          seedProgress({
+            message: `Starting ${backendName} session initialization`,
+            progress_percent: 5,
+            details: workingDirectory ? `Working directory: ${workingDirectory}` : undefined,
+          });
+        } catch (e) {
+          console.warn("⚠️ [APP] Failed to seed initial progress", e);
         }
 
         await api.start_session({

--- a/frontend/src/components/common/InlineSessionProgress.tsx
+++ b/frontend/src/components/common/InlineSessionProgress.tsx
@@ -3,7 +3,6 @@ import {
   SessionProgressPayload,
   SessionProgressStage,
 } from "../../types/session";
-import { useWittyLoadingPhrase } from "../../hooks/useWittyLoadingPhrase";
 
 interface InlineSessionProgressProps {
   progress: SessionProgressPayload | null;
@@ -14,21 +13,14 @@ export function InlineSessionProgress({
   progress,
   className,
 }: InlineSessionProgressProps) {
-  const isActive =
-    progress &&
-    progress.stage !== SessionProgressStage.Ready &&
-    progress.stage !== SessionProgressStage.Failed;
-  const { formattedMessage } = useWittyLoadingPhrase({ isActive: !!isActive });
-
   if (!progress || progress.stage === SessionProgressStage.Ready) {
     return null;
   }
 
   const isFailed = progress.stage === SessionProgressStage.Failed;
   const progressPercent = progress.progress_percent || 0;
-
-  // Use witty phrases for all non-failed states, fallback to original message only for failures
-  const displayMessage = isFailed ? progress.message : formattedMessage;
+  // Always display backend-provided progress message
+  const displayMessage = progress.message;
 
   return (
     <div className={className}>

--- a/frontend/src/components/conversation/ProcessCard.tsx
+++ b/frontend/src/components/conversation/ProcessCard.tsx
@@ -13,7 +13,7 @@ import { useTranslation } from "react-i18next";
 
 import type { Conversation, ProcessStatus } from "../../types";
 import { InlineSessionProgress } from "../common/InlineSessionProgress";
-import { SessionProgressPayload } from "../../types/session";
+import { SessionProgressPayload, SessionProgressStage } from "../../types/session";
 
 interface ProcessCardProps {
   conversation: Conversation;
@@ -343,7 +343,7 @@ export function ProcessCard({
 
         {progress &&
           activeConversation === conversation.id &&
-          progress.stage !== "ready" && (
+          progress.stage !== SessionProgressStage.Ready && (
             <div className="px-4 pb-3">
               <hr className="border-gray-200 dark:border-gray-700 mb-3" />
               <InlineSessionProgress progress={progress} className="w-full" />

--- a/frontend/src/hooks/useSessionProgress.ts
+++ b/frontend/src/hooks/useSessionProgress.ts
@@ -1,25 +1,34 @@
-import { useState, useCallback } from "react";
+import { useState, useCallback, useRef } from "react";
 import { listen } from "../lib/listen";
-import { SessionProgressPayload } from "../types/session";
+import { SessionProgressPayload, SessionProgressStage } from "../types/session";
 
 export function useSessionProgress() {
   const [progress, setProgress] = useState<SessionProgressPayload | null>(null);
   const [currentSessionId, setCurrentSessionId] = useState<string | null>(null);
+  const currentUnlistenRef = useRef<(() => void) | null>(null);
 
   const handleProgressEvent = useCallback(
     (sessionId: string, payload: SessionProgressPayload) => {
       console.log(`🔄 [SESSION-PROGRESS] Session ${sessionId}:`, payload);
-
-      if (!currentSessionId || currentSessionId === sessionId) {
-        setCurrentSessionId(sessionId);
-        setProgress(payload);
-      }
+      // Always accept events for the listener's bound sessionId
+      setCurrentSessionId(sessionId);
+      setProgress(payload);
     },
-    [currentSessionId]
+    []
   );
 
   const startListeningForSession = useCallback(
     async (sessionId: string) => {
+      // Stop any previous session-progress listener to avoid stale handlers
+      if (currentUnlistenRef.current) {
+        try {
+          currentUnlistenRef.current();
+        } catch (e) {
+          console.warn("⚠️ [SESSION-PROGRESS] Error while unlistening previous session", e);
+        }
+        currentUnlistenRef.current = null;
+      }
+
       setCurrentSessionId(sessionId);
 
       const eventName = `session-progress-${sessionId}`;
@@ -31,8 +40,17 @@ export function useSessionProgress() {
             handleProgressEvent(sessionId, event.payload);
           }
         );
-
-        return unlisten;
+        currentUnlistenRef.current = unlisten;
+        return () => {
+          try {
+            unlisten();
+          } catch (e) {
+            console.warn("⚠️ [SESSION-PROGRESS] Error while unlistening", e);
+          }
+          if (currentUnlistenRef.current === unlisten) {
+            currentUnlistenRef.current = null;
+          }
+        };
       } catch (error) {
         console.error(
           `Failed to set up session progress listener for ${sessionId}:`,
@@ -47,11 +65,29 @@ export function useSessionProgress() {
   const resetProgress = useCallback(() => {
     setProgress(null);
     setCurrentSessionId(null);
+    if (currentUnlistenRef.current) {
+      try {
+        currentUnlistenRef.current();
+      } catch (e) {
+        console.warn("⚠️ [SESSION-PROGRESS] Error while unlistening on reset", e);
+      }
+      currentUnlistenRef.current = null;
+    }
   }, []);
 
   return {
     progress,
     startListeningForSession,
     resetProgress,
+    // Optimistically seed progress before backend emits
+    seedProgress: (payload?: Partial<SessionProgressPayload>) => {
+      const seeded: SessionProgressPayload = {
+        stage: SessionProgressStage.Starting,
+        message: payload?.message || "Starting session initialization",
+        progress_percent: payload?.progress_percent ?? 5,
+        details: payload?.details,
+      };
+      setProgress(seeded);
+    },
   };
 }


### PR DESCRIPTION
Fixes the progress bar to show backend-provided session messages and ensures it appears immediately and reliably across navigation flows.

Changes

- InlineSessionProgress: display backend `SessionProgress.message` for all non-ready states; hide when `stage === Ready`.
- ProcessCard: compare `stage` using the enum (`SessionProgressStage.Ready`) instead of a raw string.
- useSessionProgress: fix stale listener issue by unlistening the previous `session-progress-<id>` handler and accepting events for the currently bound session; add `resetProgress` cleanup.
- App: seed an initial 5% “Starting … session initialization” progress (with working directory in `details`) before calling `start_session` so the bar renders instantly.

Rationale

- Early backend stages (Starting/Validating/Spawning) can emit quickly; UI previously first rendered at 40% (Initializing), making the bar “jump in” late.
- When creating a second session after returning Home, progress events were ignored due to a stale closure + not unlistening old listeners.

Verification

- Start a session from Home or Project Detail: progress appears immediately at ~5% and updates with backend messages (Starting, Validating, Spawning, Initializing).
- Create a session, return Home, create another session: progress shows for the second session as expected.

Notes

- No unrelated files changed. Frontend formatting and naming conventions preserved.
