### PR TITLE
feat(ui): prevent missed stream output in web mode

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -350,6 +350,7 @@ function RootLayoutContent() {
       createNewConversation,
       setActiveConversation,
       startListeningForSession,
+      setupEventListenerForConversation,
       seedProgress,
     ]
   );

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -313,6 +313,24 @@ function RootLayoutContent() {
           console.warn("⚠️ [APP] Failed to seed initial progress", e);
         }
 
+        // IMPORTANT: Attach conversation event listeners BEFORE starting the session
+        // to avoid losing early streaming chunks (race observed in web mode).
+        try {
+          if (!listenerCleanups.current.has(convId)) {
+            const cleanup = await setupEventListenerForConversation(convId);
+            listenerCleanups.current.set(convId, cleanup);
+            console.log(
+              "👂 [APP] Pre-attached conversation listeners before start_session:",
+              convId
+            );
+          }
+        } catch (e) {
+          console.error(
+            "❌ [APP] Failed to pre-attach conversation listeners:",
+            e
+          );
+        }
+
         await api.start_session({
           sessionId: convId,
           workingDirectory,

--- a/frontend/src/hooks/useConversationEvents.ts
+++ b/frontend/src/hooks/useConversationEvents.ts
@@ -1,4 +1,5 @@
 import React, { useCallback, useRef } from "react";
+import type { TextMessagePart } from "../types";
 import { listen } from "@/lib/listen";
 import { getWebSocketManager } from "../lib/webApi";
 import { Conversation, Message, CliIO } from "../types";
@@ -885,8 +886,9 @@ export const useConversationEvents = (
                   lastMsg.parts.length > 0 &&
                   lastMsg.parts[lastMsg.parts.length - 1].type === "text"
                 ) {
-                  (lastMsg.parts[lastMsg.parts.length - 1] as any).text +=
-                    buffered;
+                  (
+                    lastMsg.parts[lastMsg.parts.length - 1] as TextMessagePart
+                  ).text += buffered;
                 } else {
                   conv.messages.push({
                     id: Date.now().toString(),


### PR DESCRIPTION
Summary
- Ensure streamed assistant output reliably appears in web mode.
- Fix a race where listeners attached after start_session could miss early chunks.

Changes
- Pre‑attach conversation listeners before starting a session (web mode).
- Buffer assistant text seen on CLI JSON‑RPC and inject on turn‑finish if no ai‑output was received.
- Clear buffered state on cleanup to avoid cross‑turn bleed‑through.

Why
- Some users reported “CLI shows output but UI doesn’t.” This addresses timing issues between backend events and frontend listeners and adds a safe fallback.

Testing
- Run: `just dev-web`.
- Start a new session from a directory; immediately send a prompt.
- Confirm text streams live; if not, the final message still appears when the turn ends.
- Also test sending from an empty chat.

Revertability
- The fallback is isolated and easy to remove if not needed.
