### PR TITLE
Fix conversation auto-scroll and yolo mode tool approvals

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -59,7 +59,6 @@ function RootLayoutContent() {
   const [selectedModel, setSelectedModel] =
     useState<string>("gemini-2.5-flash");
   const [cliIOLogs, setCliIOLogs] = useState<CliIO[]>([]);
-  const messagesContainerRef = useRef<HTMLDivElement>(null);
   const [sidebarOpen, setSidebarOpen] = useState(true);
   const [directoryPanelOpen, setDirectoryPanelOpen] = useState(false);
   const [searchOpen, setSearchOpen] = useState(false);
@@ -458,7 +457,6 @@ function RootLayoutContent() {
       currentConversation,
       input,
       isCliInstalled,
-      messagesContainerRef,
       cliIOLogs,
       handleInputChange,
       handleSendMessage,
@@ -476,7 +474,6 @@ function RootLayoutContent() {
       currentConversation,
       input,
       isCliInstalled,
-      messagesContainerRef,
       cliIOLogs,
       handleInputChange,
       handleSendMessage,

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -158,10 +158,18 @@ function RootLayoutContent() {
     updateConversation,
   });
 
+  // Get yolo mode status from backend config
+  const isYoloEnabled = backendState.selectedBackend === "gemini"
+    ? backendState.configs.gemini.yolo
+    : backendState.selectedBackend === "qwen"
+      ? backendState.configs.qwen.yolo
+      : false;
+
   const { setupEventListenerForConversation } = useConversationEvents(
     setCliIOLogs,
     setConfirmationRequests,
-    updateConversation
+    updateConversation,
+    isYoloEnabled
   );
 
   const { input, handleInputChange, handleSendMessage } = useMessageHandler({

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -158,11 +158,12 @@ function RootLayoutContent() {
   });
 
   // Get yolo mode status from backend config
-  const isYoloEnabled = backendState.selectedBackend === "gemini"
-    ? backendState.configs.gemini.yolo
-    : backendState.selectedBackend === "qwen"
-      ? backendState.configs.qwen.yolo
-      : false;
+  const isYoloEnabled =
+    backendState.selectedBackend === "gemini"
+      ? backendState.configs.gemini.yolo
+      : backendState.selectedBackend === "qwen"
+        ? backendState.configs.qwen.yolo
+        : false;
 
   const { setupEventListenerForConversation } = useConversationEvents(
     setCliIOLogs,

--- a/frontend/src/contexts/ConversationContext.tsx
+++ b/frontend/src/contexts/ConversationContext.tsx
@@ -4,14 +4,16 @@ import { ToolCallConfirmationRequest } from "../utils/toolCallParser";
 import { ConversationHistoryEntry } from "../lib/webApi";
 import { SessionProgressPayload } from "../types/session";
 
-// Context for sharing conversation state with child routes
+/**
+ * Context type for sharing conversation state with child routes.
+ * Provides conversation management, message handling, and tool call confirmation.
+ */
 export interface ConversationContextType {
   conversations: Conversation[];
   activeConversation: string | null;
   currentConversation: Conversation | undefined;
   input: string;
   isCliInstalled: boolean | null;
-  messagesContainerRef: React.RefObject<HTMLDivElement | null>;
   cliIOLogs: CliIO[];
   handleInputChange: (
     _event: React.ChangeEvent<HTMLTextAreaElement> | null,
@@ -43,6 +45,11 @@ export const ConversationContext = createContext<
   ConversationContextType | undefined
 >(undefined);
 
+/**
+ * Custom hook to access the conversation context.
+ * @returns The conversation context value.
+ * @throws Error if used outside of a ConversationProvider.
+ */
 export const useConversation = () => {
   const context = useContext(ConversationContext);
   if (context === undefined) {

--- a/frontend/src/hooks/useConversationEvents.ts
+++ b/frontend/src/hooks/useConversationEvents.ts
@@ -265,7 +265,7 @@ function getOptionKind(
 /**
  * Custom hook to set up event listeners for conversation events.
  * Handles CLI I/O logging, tool call confirmations, and AI turn events.
- * 
+ *
  * @param setCliIOLogs - State setter for CLI input/output logs
  * @param setConfirmationRequests - State setter for tool call confirmation requests
  * @param updateConversation - Function to update conversation state
@@ -294,7 +294,7 @@ export const useConversationEvents = (
   /**
    * Sets up event listeners for a specific conversation.
    * Listens for CLI I/O events, tool call confirmations, and AI turn events.
-   * 
+   *
    * @param conversationId - The ID of the conversation to listen to
    * @returns Cleanup function to remove all event listeners
    */
@@ -922,24 +922,25 @@ export const useConversationEvents = (
 
             // If yolo mode is enabled, auto-approve the tool call
             if (isYoloEnabledRef.current) {
-              console.log(
-                `🤖 [YOLO] Auto-approving tool call: ${toolCallId}`
-              );
+              console.log(`🤖 [YOLO] Auto-approving tool call: ${toolCallId}`);
               // Find the "allow_always" or "allow_once" option and use it
               const autoApproveOption = legacyConfirmationRequest.options?.find(
-                (opt) => opt.kind === "allow_always" || opt.kind === "allow_once"
+                (opt) =>
+                  opt.kind === "allow_always" || opt.kind === "allow_once"
               );
               const outcome = autoApproveOption?.optionId || "proceed_always";
 
               // Send approval response to backend
-              api.send_tool_call_confirmation_response({
-                sessionId: conversationId,
-                requestId: legacyConfirmationRequest.requestId,
-                toolCallId: toolCallId,
-                outcome: outcome,
-              }).catch((err) => {
-                console.error("Failed to send auto-approve response:", err);
-              });
+              api
+                .send_tool_call_confirmation_response({
+                  sessionId: conversationId,
+                  requestId: legacyConfirmationRequest.requestId,
+                  toolCallId: toolCallId,
+                  outcome: outcome,
+                })
+                .catch((err) => {
+                  console.error("Failed to send auto-approve response:", err);
+                });
             } else {
               // Only store confirmation request if yolo mode is disabled
               setConfirmationRequests((prev) => {

--- a/frontend/src/hooks/useConversationEvents.ts
+++ b/frontend/src/hooks/useConversationEvents.ts
@@ -2,6 +2,7 @@ import React, { useCallback, useRef } from "react";
 import type { TextMessagePart } from "../types";
 import { listen } from "@/lib/listen";
 import { getWebSocketManager } from "../lib/webApi";
+import { api } from "../lib/api";
 import { Conversation, Message, CliIO } from "../types";
 import { ToolCallConfirmationRequest } from "../utils/toolCallParser";
 import { type ToolCall } from "../utils/toolCallParser";
@@ -269,7 +270,8 @@ export const useConversationEvents = (
   updateConversation: (
     conversationId: string,
     updateFn: (conv: Conversation, lastMsg: Message) => void
-  ) => void
+  ) => void,
+  isYoloEnabled?: boolean
 ) => {
   // Buffer agent text chunks seen on CLI output in case the UI misses
   // ai-output streaming events (web WS race). Cleared on turn finish.
@@ -898,19 +900,42 @@ export const useConversationEvents = (
                 : [],
             };
 
-            setConfirmationRequests((prev) => {
-              const newMap = new Map(prev);
-              newMap.set(toolCallId, legacyConfirmationRequest);
+            // If yolo mode is enabled, auto-approve the tool call
+            if (isYoloEnabled) {
               console.log(
-                `✅ Stored confirmation request in Map for toolCallId:`,
-                toolCallId
+                `🤖 [YOLO] Auto-approving tool call: ${toolCallId}`
               );
-              console.log(
-                `✅ Total confirmation requests in Map:`,
-                newMap.size
+              // Find the "allow_always" or "allow_once" option and use it
+              const autoApproveOption = legacyConfirmationRequest.options?.find(
+                (opt) => opt.kind === "allow_always" || opt.kind === "allow_once"
               );
-              return newMap;
-            });
+              const outcome = autoApproveOption?.optionId || "proceed_always";
+
+              // Send approval response to backend
+              api.send_tool_call_confirmation_response({
+                sessionId: conversationId,
+                requestId: legacyConfirmationRequest.requestId,
+                toolCallId: toolCallId,
+                outcome: outcome,
+              }).catch((err) => {
+                console.error("Failed to send auto-approve response:", err);
+              });
+            } else {
+              // Only store confirmation request if yolo mode is disabled
+              setConfirmationRequests((prev) => {
+                const newMap = new Map(prev);
+                newMap.set(toolCallId, legacyConfirmationRequest);
+                console.log(
+                  `✅ Stored confirmation request in Map for toolCallId:`,
+                  toolCallId
+                );
+                console.log(
+                  `✅ Total confirmation requests in Map:`,
+                  newMap.size
+                );
+                return newMap;
+              });
+            }
           }
         );
         unlistenFunctions.push(unlistenAcpPermissionRequest);
@@ -981,7 +1006,7 @@ export const useConversationEvents = (
         sawAiOutputRef.current.delete(conversationId);
       };
     },
-    [setCliIOLogs, setConfirmationRequests, updateConversation]
+    [setCliIOLogs, setConfirmationRequests, updateConversation, isYoloEnabled]
   );
 
   return { setupEventListenerForConversation };

--- a/frontend/src/hooks/useConversationEvents.ts
+++ b/frontend/src/hooks/useConversationEvents.ts
@@ -262,6 +262,16 @@ function getOptionKind(
   }
 }
 
+/**
+ * Custom hook to set up event listeners for conversation events.
+ * Handles CLI I/O logging, tool call confirmations, and AI turn events.
+ * 
+ * @param setCliIOLogs - State setter for CLI input/output logs
+ * @param setConfirmationRequests - State setter for tool call confirmation requests
+ * @param updateConversation - Function to update conversation state
+ * @param isYoloEnabled - Optional flag to enable yolo mode (auto-approve tool calls)
+ * @returns Object with setupEventListenerForConversation function
+ */
 export const useConversationEvents = (
   setCliIOLogs: React.Dispatch<React.SetStateAction<CliIO[]>>,
   setConfirmationRequests: React.Dispatch<
@@ -277,7 +287,17 @@ export const useConversationEvents = (
   // ai-output streaming events (web WS race). Cleared on turn finish.
   const pendingAssistantTextRef = useRef<Map<string, string>>(new Map());
   const sawAiOutputRef = useRef<Map<string, boolean>>(new Map());
+  // Use ref to avoid re-creating listeners when yolo mode toggles
+  const isYoloEnabledRef = useRef<boolean>(isYoloEnabled ?? false);
+  isYoloEnabledRef.current = isYoloEnabled ?? false;
 
+  /**
+   * Sets up event listeners for a specific conversation.
+   * Listens for CLI I/O events, tool call confirmations, and AI turn events.
+   * 
+   * @param conversationId - The ID of the conversation to listen to
+   * @returns Cleanup function to remove all event listeners
+   */
   const setupEventListenerForConversation = useCallback(
     async (conversationId: string): Promise<() => void> => {
       // In web mode, ensure WebSocket connection is ready before registering listeners
@@ -901,7 +921,7 @@ export const useConversationEvents = (
             };
 
             // If yolo mode is enabled, auto-approve the tool call
-            if (isYoloEnabled) {
+            if (isYoloEnabledRef.current) {
               console.log(
                 `🤖 [YOLO] Auto-approving tool call: ${toolCallId}`
               );
@@ -1006,7 +1026,7 @@ export const useConversationEvents = (
         sawAiOutputRef.current.delete(conversationId);
       };
     },
-    [setCliIOLogs, setConfirmationRequests, updateConversation, isYoloEnabled]
+    [setCliIOLogs, setConfirmationRequests, updateConversation]
   );
 
   return { setupEventListenerForConversation };

--- a/frontend/src/hooks/useConversationEvents.ts
+++ b/frontend/src/hooks/useConversationEvents.ts
@@ -922,25 +922,33 @@ export const useConversationEvents = (
 
             // If yolo mode is enabled, auto-approve the tool call
             if (isYoloEnabledRef.current) {
-              console.log(`🤖 [YOLO] Auto-approving tool call: ${toolCallId}`);
+              console.log(
+                `🤖 [YOLO] Auto-approving tool call: ${toolCallId}`,
+                legacyConfirmationRequest
+              );
               // Find the "allow_always" or "allow_once" option and use it
               const autoApproveOption = legacyConfirmationRequest.options?.find(
                 (opt) =>
                   opt.kind === "allow_always" || opt.kind === "allow_once"
               );
               const outcome = autoApproveOption?.optionId || "proceed_always";
-
-              // Send approval response to backend
-              api
-                .send_tool_call_confirmation_response({
-                  sessionId: conversationId,
-                  requestId: legacyConfirmationRequest.requestId,
-                  toolCallId: toolCallId,
-                  outcome: outcome,
-                })
-                .catch((err) => {
-                  console.error("Failed to send auto-approve response:", err);
-                });
+              if (!request.sessionId) {
+                console.error(
+                  `🤖 [YOLO] No sessionId found for tool call: ${toolCallId}`
+                );
+              } else {
+                // Send approval response to backend
+                api
+                  .send_tool_call_confirmation_response({
+                    sessionId: request.sessionId,
+                    requestId: legacyConfirmationRequest.requestId,
+                    toolCallId: toolCallId,
+                    outcome: outcome,
+                  })
+                  .catch((err) => {
+                    console.error("Failed to send auto-approve response:", err);
+                  });
+              }
             } else {
               // Only store confirmation request if yolo mode is disabled
               setConfirmationRequests((prev) => {

--- a/frontend/src/hooks/useConversationEvents.ts
+++ b/frontend/src/hooks/useConversationEvents.ts
@@ -926,11 +926,15 @@ export const useConversationEvents = (
                 `🤖 [YOLO] Auto-approving tool call: ${toolCallId}`,
                 legacyConfirmationRequest
               );
-              // Find the "allow_always" or "allow_once" option and use it
-              const autoApproveOption = legacyConfirmationRequest.options?.find(
-                (opt) =>
-                  opt.kind === "allow_always" || opt.kind === "allow_once"
-              );
+              // Find the best auto-approve option, preferring allow_always
+              // over allow_once so YOLO mode doesn't re-prompt for the same tool.
+              const autoApproveOption =
+                legacyConfirmationRequest.options?.find(
+                  (opt) => opt.kind === "allow_always"
+                ) ??
+                legacyConfirmationRequest.options?.find(
+                  (opt) => opt.kind === "allow_once"
+                );
               const outcome = autoApproveOption?.optionId || "proceed_always";
               if (!request.sessionId) {
                 console.error(
@@ -947,6 +951,17 @@ export const useConversationEvents = (
                   })
                   .catch((err) => {
                     console.error("Failed to send auto-approve response:", err);
+                    // Fall back to showing the confirmation dialog so the user
+                    // can manually approve and the call doesn't get stuck.
+                    setConfirmationRequests((prev) => {
+                      const newMap = new Map(prev);
+                      newMap.set(toolCallId, legacyConfirmationRequest);
+                      console.log(
+                        `⚠️ [YOLO] Auto-approve failed, falling back to manual confirmation for toolCallId:`,
+                        toolCallId
+                      );
+                      return newMap;
+                    });
                   });
               }
             } else {

--- a/frontend/src/pages/HomeDashboard.tsx
+++ b/frontend/src/pages/HomeDashboard.tsx
@@ -35,7 +35,6 @@ export const HomeDashboard: React.FC = () => {
   const navigate = useNavigate();
   const {
     currentConversation,
-    messagesContainerRef,
     handleConfirmToolCall,
     confirmationRequests,
   } = useConversation();
@@ -46,6 +45,44 @@ export const HomeDashboard: React.FC = () => {
   const { selectedBackend } = useBackend();
   const backendText = getBackendText(selectedBackend);
 
+  // Use a local ref for auto-scrolling
+  const localContainerRef = React.useRef<HTMLDivElement>(null);
+
+  // Track if user is near bottom (for auto-scroll behavior)
+  const isNearBottomRef = React.useRef(true);
+
+  // Listen for scroll events to track user position
+  React.useEffect(() => {
+    const container = localContainerRef.current;
+    if (!container) return;
+
+    const handleScroll = () => {
+      const threshold = 100; // pixels from bottom
+      const position = container.scrollTop + container.clientHeight;
+      const height = container.scrollHeight;
+      isNearBottomRef.current = height - position < threshold;
+    };
+
+    container.addEventListener('scroll', handleScroll, { passive: true });
+    return () => container.removeEventListener('scroll', handleScroll);
+  }, []);
+
+  // Auto-scroll to bottom when new messages arrive (only if user is near bottom)
+  React.useEffect(() => {
+    const container = localContainerRef.current;
+    if (container && currentConversation?.messages.length) {
+      // Use setTimeout with 0 to ensure DOM has fully rendered
+      setTimeout(() => {
+        if (container && isNearBottomRef.current) {
+          container.scrollTop = container.scrollHeight;
+        }
+      }, 0);
+    }
+  }, [
+    currentConversation?.messages.length,
+    currentConversation?.isStreaming
+  ]);
+
   return (
     <>
       {currentConversation ? (
@@ -53,7 +90,7 @@ export const HomeDashboard: React.FC = () => {
           <NewChatPlaceholder />
         ) : (
           <div
-            ref={messagesContainerRef as React.RefObject<HTMLDivElement>}
+            ref={localContainerRef}
             className="flex-1 min-h-0 overflow-y-auto p-6 relative"
           >
             <div className="space-y-8 pb-4">

--- a/frontend/src/pages/HomeDashboard.tsx
+++ b/frontend/src/pages/HomeDashboard.tsx
@@ -39,9 +39,6 @@ export const HomeDashboard: React.FC = () => {
     confirmationRequests,
   } = useConversation();
 
-  // Debug logging for currentConversation
-  console.log("🏠 HomeDashboard - currentConversation:", currentConversation);
-
   const { selectedBackend } = useBackend();
   const backendText = getBackendText(selectedBackend);
 
@@ -50,6 +47,8 @@ export const HomeDashboard: React.FC = () => {
 
   // Track if user is near bottom (for auto-scroll behavior)
   const isNearBottomRef = React.useRef(true);
+  // Track previous scroll height to detect content growth
+  const prevScrollHeightRef = React.useRef<number>(0);
 
   // Listen for scroll events to track user position
   React.useEffect(() => {
@@ -67,21 +66,37 @@ export const HomeDashboard: React.FC = () => {
     return () => container.removeEventListener('scroll', handleScroll);
   }, []);
 
-  // Auto-scroll to bottom when new messages arrive (only if user is near bottom)
+  // Auto-scroll to bottom when content grows (only if user is near bottom)
   React.useEffect(() => {
     const container = localContainerRef.current;
-    if (container && currentConversation?.messages.length) {
-      // Use setTimeout with 0 to ensure DOM has fully rendered
-      setTimeout(() => {
-        if (container && isNearBottomRef.current) {
+    if (!container || !currentConversation?.messages.length) return;
+
+    // Use ResizeObserver to detect when content height changes
+    const observer = new ResizeObserver(() => {
+      const newHeight = container.scrollHeight;
+      const prevHeight = prevScrollHeightRef.current;
+      
+      // Only scroll if content grew and user is near bottom
+      if (newHeight > prevHeight && isNearBottomRef.current) {
+        // Use requestAnimationFrame for smooth scrolling
+        requestAnimationFrame(() => {
           container.scrollTop = container.scrollHeight;
-        }
-      }, 0);
+        });
+      }
+      
+      prevScrollHeightRef.current = newHeight;
+    });
+
+    // Observe the content container (the div with space-y-8)
+    const contentContainer = container.firstElementChild;
+    if (contentContainer) {
+      observer.observe(contentContainer);
+      // Initial height capture
+      prevScrollHeightRef.current = container.scrollHeight;
     }
-  }, [
-    currentConversation?.messages.length,
-    currentConversation?.isStreaming
-  ]);
+
+    return () => observer.disconnect();
+  }, [currentConversation?.messages.length]);
 
   return (
     <>

--- a/frontend/src/pages/HomeDashboard.tsx
+++ b/frontend/src/pages/HomeDashboard.tsx
@@ -33,11 +33,8 @@ import { GeminiMessagePart } from "../types";
 export const HomeDashboard: React.FC = () => {
   const { t } = useTranslation();
   const navigate = useNavigate();
-  const {
-    currentConversation,
-    handleConfirmToolCall,
-    confirmationRequests,
-  } = useConversation();
+  const { currentConversation, handleConfirmToolCall, confirmationRequests } =
+    useConversation();
 
   const { selectedBackend } = useBackend();
   const backendText = getBackendText(selectedBackend);
@@ -62,8 +59,8 @@ export const HomeDashboard: React.FC = () => {
       isNearBottomRef.current = height - position < threshold;
     };
 
-    container.addEventListener('scroll', handleScroll, { passive: true });
-    return () => container.removeEventListener('scroll', handleScroll);
+    container.addEventListener("scroll", handleScroll, { passive: true });
+    return () => container.removeEventListener("scroll", handleScroll);
   }, []);
 
   // Auto-scroll to bottom when content grows (only if user is near bottom)
@@ -75,7 +72,7 @@ export const HomeDashboard: React.FC = () => {
     const observer = new ResizeObserver(() => {
       const newHeight = container.scrollHeight;
       const prevHeight = prevScrollHeightRef.current;
-      
+
       // Only scroll if content grew and user is near bottom
       if (newHeight > prevHeight && isNearBottomRef.current) {
         // Use requestAnimationFrame for smooth scrolling
@@ -83,7 +80,7 @@ export const HomeDashboard: React.FC = () => {
           container.scrollTop = container.scrollHeight;
         });
       }
-      
+
       prevScrollHeightRef.current = newHeight;
     });
 


### PR DESCRIPTION
## Changes
     
### 1. Fix Conversation Auto-Scroll
The conversation window now auto-scrolls to new messages, but only when the user is near the bottom. This prevents annoying jumps when scrolling up to read previous messages.
      
- Auto-scroll follows new messages when user is within 100px of bottom
- Scrolling up disables auto-scroll until user returns to bottom
 - Uses local ref and scroll event listener for reliable behavior
      
### 2. Fix Yolo Mode Auto-Approve
When yolo mode is enabled, tool calls are now automatically approved without requiring manual confirmation.
     
- Detects yolo mode from backend config (supports Gemini and Qwen)
- Automatically sends approval response to backend for tool call requests
- Prevents confirmation dialogs from appearing when yolo is enabled
    
## Testing
- Verified auto-scroll works when at bottom of conversation
- Verified auto-scroll is disabled when scrolled up
- Verified yolo mode auto-approves tool calls without prompts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * YOLO mode: optionally auto-approves tool calls based on backend configuration to streamline confirmations.
  * Smarter auto-scroll: only scrolls when the user is near the bottom, improving chat UX.

* **Refactor**
  * Simplified conversation context by removing the exposed messages container ref and providing a convenience hook for access.

* **Documentation**
  * Added docstrings/documentation for the conversation hook and event-handling behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->