### PR TITLE
feat: add delete_conversation and delete_project REST API endpoints

### DIFF
--- a/crates/server/src/main.rs
+++ b/crates/server/src/main.rs
@@ -1,7 +1,7 @@
 use anyhow::{Context, Error as AnyhowError};
 use include_dir::{Dir, include_dir};
 use rocket::{
-    Request, Response, Shutdown, State, get,
+    Request, Response, Shutdown, State, delete, get,
     http::{ContentType, Status},
     post,
     response::{self, Responder},
@@ -327,6 +327,12 @@ struct WriteFileContentRequest {
     content: String,
 }
 
+#[derive(Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct DeleteProjectRequest {
+    project_id: String,
+}
+
 #[derive(Debug)]
 pub struct AnyhowResponder(pub AnyhowError);
 
@@ -505,6 +511,30 @@ async fn export_conversation_history(
         .await
         .context("Failed to export conversation history")
         .map_err(AnyhowResponder)
+}
+
+#[delete("/conversations/<chat_id>")]
+async fn delete_conversation(chat_id: String, state: &State<AppState>) -> AppResult<()> {
+    let decoded_chat_id = urlencoding::decode(&chat_id)
+        .map_err(|e| AnyhowError::msg(format!("Failed to decode chat ID: {}", e)))?;
+
+    let backend = state.backend.lock().await;
+    Ok(backend
+        .delete_conversation(&decoded_chat_id)
+        .await
+        .context("Failed to delete conversation")?)
+}
+
+#[post("/delete-project", data = "<request>")]
+async fn delete_project(
+    request: Json<DeleteProjectRequest>,
+    state: &State<AppState>,
+) -> AppResult<()> {
+    let backend = state.backend.lock().await;
+    Ok(backend
+        .delete_project(&request.project_id)
+        .await
+        .context("Failed to delete project")?)
 }
 
 #[get("/check-cli-installed")]
@@ -922,6 +952,8 @@ fn rocket() -> _ {
             get_project_discussions,
             get_detailed_conversation,
             export_conversation_history,
+            delete_conversation,
+            delete_project,
             read_file_content,
             read_binary_file_as_base64,
             get_canonical_path,


### PR DESCRIPTION
## Summary

Fixes #193 — **Delete discussion not working in web mode.**

Both `delete_conversation` and `delete_project` were available as Tauri commands (desktop mode) but had no corresponding Rocket route handlers in the web server, causing these operations to fail in web mode.

## Changes

**Single file modified:** `crates/server/src/main.rs` (+33 lines, -1 line)

- Import Rocket's `delete` macro for HTTP DELETE route support
- Add `DELETE /api/conversations/<chat_id>` endpoint with URL decoding (matches `apiClient.delete()` in `webApi.ts`)
- Add `POST /api/delete-project` endpoint with `DeleteProjectRequest` struct (matches `apiClient.post()` in `webApi.ts`)
- Register both new routes in the Rocket mount configuration

## How It Was Broken

| Layer | `delete_conversation` | `delete_project` |
|---|---|---|
| Frontend UI | ✅ `ProjectDetail.tsx` | ✅ `Projects.tsx` |
| API Interface | ✅ `api.ts` | ✅ `api.ts` |
| Web API client | ✅ `webApi.ts` (DELETE) | ✅ `webApi.ts` (POST) |
| **Rocket Server** | ❌ **Missing** | ❌ **Missing** |
| Backend Core | ✅ `backend/lib.rs` | ✅ `backend/lib.rs` |
| Tauri Command | ✅ `commands/mod.rs` | ✅ `commands/mod.rs` |

The frontend, API interface, web API client, and backend logic all existed — only the Rocket HTTP route handlers were missing, breaking the bridge in web mode.

## Verification

- `cargo build --workspace` — ✅ clean
- `cargo clippy --package server -- -D warnings` — ✅ zero warnings
- **Manually tested** — ✅ conversation deleted successfully

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Users can now delete individual conversations.
  * Users can now delete projects.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->